### PR TITLE
Feat/11 - 재고 원상복구 로직 구현

### DIFF
--- a/api-test/inventory.http
+++ b/api-test/inventory.http
@@ -26,20 +26,26 @@ Content-Type: application/json
 }
 
 > {%
-    client.global.set("auth_token", response.body.data.accessToken);
+    var token = response.body.data.accessToken;
+    client.global.set("auth_token", token);
+
+    client.log("=======================================");
+    client.log("[로그인 성공]");
+    client.log("저장된 auth_token: " + token);
+    client.log("=======================================");
 %}
 
 
-### 2. [Admin] 상품 등록 (ID 자동 저장)
+### 2. [Admin] 상품 등록 (RDB 저장 및 product.created 카프카 발행)
 POST http://{{host}}:{{gatewayPort}}/api/v1/products
 Content-Type: application/json
 Authorization: Bearer {{auth_token}}
 
 {
     "restaurantId": "550e8400-e29b-41d4-a716-446655440000",
-    "name": "44 프리미엄 밀키트 세트",
+    "name": "44 미슐랭 3스타 시그니처 코스",
     "category": "MEALKIT",
-    "basePrice": 25000,
+    "basePrice": 150000,
     "attributes": {
         "origin": "국내산"
     },
@@ -49,7 +55,14 @@ Authorization: Bearer {{auth_token}}
     },
     "options": [
         {
-            "name": "기본 선택",
+            "name": "44 와인 페어링 추가",
+            "addPrice": 50000,
+            "totalQuantity": 100,
+            "dailyLimit": 20,
+            "maxLimit": 5
+        },
+        {
+            "name": "44 기본 선택",
             "addPrice": 0,
             "totalQuantity": 100,
             "dailyLimit": 20,
@@ -59,29 +72,67 @@ Authorization: Bearer {{auth_token}}
 }
 
 > {%
-    client.global.set("shared_product_id", response.body.data.productId);
-    // 배열이 존재하고 길이가 0보다 클 때만 안전하게 옵션 ID 추출
-    if (response.body.data.options && response.body.data.options.length > 0) {
-        client.global.set("shared_option_id", response.body.data.options[0].optionId);
+    // 1. 응답 성공 여부 확인
+    if (response.status >= 200 && response.status < 300 && response.body && response.body.data) {
+        var data = response.body.data;
+
+        // 2. Product ID 저장 및 로그
+        if (data.productId) {
+            client.global.set("shared_product_id", data.productId);
+            client.log("[성공] 저장된 공유 물품 아이디: " + data.productId);
+        } else {
+            client.log("[경고] productId가 응답 데이터에 없습니다.");
+        }
+
+        // 3. Options 안전하게 추출
+        if (data.options && data.options.length > 0) {
+            var optionId = data.options[0].optionId;
+            client.global.set("shared_option_id", optionId);
+            client.log("[성공] 저장된 공유 옵션 아이디: " + optionId);
+        } else {
+            client.log("[경고] options 데이터가 비어있습니다.");
+        }
+
     } else {
-        client.log("Warning: 응답에 options 데이터가 없습니다. shared_option_id를 설정하지 않습니다.");
+        // 에러 발생 시 로그
+        client.log("[에러] API 요청 실패 또는 데이터가 없습니다. (Status: " + response.status + ")");
+        if (response.body && response.body.message) {
+            client.log("상세: " + response.body.message);
+        }
     }
 %}
 
 
-### 3. [Internal] 재고 선점 (등록된 ID 사용)
+### 3. [Internal] 재고 차감/선점 (RDB 차감 및 stock.reserved 카프카 발행)
 POST http://{{host}}:{{inventoryPort}}/internal/stocks/reserve
 Content-Type: application/json
-X-User-Id: system-id
 X-User-Role: SYSTEM
 
 {
   "optionId": "{{shared_option_id}}",
-  "quantity": 1
+  "quantity": 3
 }
 
 > {%
     client.test("재고 선점 성공 확인", function () {
         client.assert(response.status === 200, "재고 선점에 실패했습니다.");
     });
+    client.log("재고 선점 테스트 대상 공유 옵션 아이디: " + client.global.get("shared_option_id"));
+%}
+
+### 4. [Internal] 재고 복구 (결제 실패 시 RDB 복구 및 stock.restored 카프카 발행)
+POST http://{{host}}:{{inventoryPort}}/internal/stocks/restore
+Content-Type: application/json
+X-User-Role: SYSTEM
+
+{
+  "optionId": "{{shared_option_id}}",
+  "quantity": 3
+}
+
+> {%
+    client.test("재고 복구 성공 확인", function () {
+        client.assert(response.status === 200, "재고 복구에 실패했습니다.");
+    });
+    client.log("재고 복구 테스트 대상 공유 옵션 아이디: " + client.global.get("shared_option_id"));
 %}

--- a/api-test/inventory.http
+++ b/api-test/inventory.http
@@ -43,7 +43,7 @@ Authorization: Bearer {{auth_token}}
 
 {
     "restaurantId": "550e8400-e29b-41d4-a716-446655440000",
-    "name": "44 미슐랭 3스타 시그니처 코스",
+    "name": "미슐랭 3스타 시그니처 코스",
     "category": "MEALKIT",
     "basePrice": 150000,
     "attributes": {
@@ -55,14 +55,14 @@ Authorization: Bearer {{auth_token}}
     },
     "options": [
         {
-            "name": "44 와인 페어링 추가",
+            "name": "와인 페어링 추가",
             "addPrice": 50000,
             "totalQuantity": 100,
             "dailyLimit": 20,
             "maxLimit": 5
         },
         {
-            "name": "44 기본 선택",
+            "name": "기본 선택",
             "addPrice": 0,
             "totalQuantity": 100,
             "dailyLimit": 20,

--- a/src/main/java/com/michelet/inventory/application/ProductCommandService.java
+++ b/src/main/java/com/michelet/inventory/application/ProductCommandService.java
@@ -15,6 +15,7 @@ import java.util.ArrayList;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -33,6 +34,9 @@ public class ProductCommandService {
     private final StockRepository stockRepository;
 
     private final KafkaTemplate<String, Object> kafkaTemplate;
+
+    @Value("${inventory.kafka.topic.product-created:product.created}")
+    private String topicProductCreated;
 
     @Transactional(readOnly = true)
     public String checkHealth() {
@@ -104,6 +108,7 @@ public class ProductCommandService {
             command.restaurantId(),
             command.name(),
             command.category().name(),
+            product.getBasePrice(),
             command.attributes(),
             command.exhibition().startAt(),
             command.exhibition().endAt(),
@@ -134,7 +139,7 @@ public class ProductCommandService {
     // 카프카 전송 및 콜백 확인용 내부 메서드
     private void sendKafkaMessageWithCallback(ProductCreatedEvent event) {
         log.info("DB 커밋 완료. 상품 등록 이벤트 발행 요청: productId={}", event.productId());
-        kafkaTemplate.send("product.created", event.productId().toString(), event)
+        kafkaTemplate.send(topicProductCreated, event.productId().toString(), event)
             .whenComplete((result, ex) -> {
                 if (ex == null) {
                     log.info("상품 등록 이벤트 발행 실제 성공: productId={}, offset={}",

--- a/src/main/java/com/michelet/inventory/application/StockCommandService.java
+++ b/src/main/java/com/michelet/inventory/application/StockCommandService.java
@@ -1,11 +1,16 @@
 package com.michelet.inventory.application;
 
 import com.michelet.inventory.application.dto.StockReservedEvent;
+import com.michelet.inventory.application.dto.StockRestoredEvent;
+import com.michelet.inventory.domain.exception.ConcurrencyFailureException;
+import com.michelet.inventory.domain.exception.StockNotFoundException;
 import com.michelet.inventory.domain.model.Stock;
 import com.michelet.inventory.domain.repository.StockRepository;
 import com.michelet.inventory.presentation.dto.ReserveStockRequest;
+import com.michelet.inventory.presentation.dto.RestoreStockRequest;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.orm.ObjectOptimisticLockingFailureException;
 import org.springframework.stereotype.Service;
@@ -20,46 +25,46 @@ public class StockCommandService {
     private final KafkaTemplate<String, Object> kafkaTemplate;
     private final TransactionTemplate transactionTemplate; // 트랜잭션을 수동으로 제어하기 위해 주입
 
-    private static final int MAX_RETRY_COUNT = 3;
-    private static final String TOPIC_STOCK_RESERVED = "stock.reserved";
+    @Value("${inventory.retry.max-count:3}")
+    private int maxRetryCount;
+
+    @Value("${inventory.kafka.topic.reserved:stock.reserved}")
+    private String topicStockReserved;
+
+    @Value("${inventory.kafka.topic.restored:stock.restored}")
+    private String topicStockRestored;
 
     // @Transactional을 제거 - AOP Self-Invocation 방지
     public void reserveStockWithRetry(ReserveStockRequest request) {
         int retryCount = 0;
-        while (retryCount < MAX_RETRY_COUNT) {
+        while (retryCount < maxRetryCount) {
             try {
                 // 1. 매 재시도마다 독립된 새로운 트랜잭션을 연다
                 StockReservedEvent event = transactionTemplate.execute(status -> reserveStockInternal(request));
 
                 // 2. TransactionTemplate이 에러 없이 끝나면 DB 커밋이 완료된 것
                 // Fire-and-forget 방지. whenComplete 콜백을 달아 전송 실패 시 인지 및 후속 처리 가능하도록 수정
-                kafkaTemplate.send(TOPIC_STOCK_RESERVED, request.optionId().toString(), event)
+                kafkaTemplate.send(topicStockReserved, request.optionId().toString(), event)
                     .whenComplete((result, ex) -> {
                         if (ex != null) {
                             log.error("Kafka 메시지 발행 실패 (데이터 불일치 위험)! optionId: {}", request.optionId(), ex);
-                            // 추후 재처리 로직이나 아웃박스 패턴으로 고도화 필요
+                            // TODO 추후 재처리 로직이나 아웃박스 패턴으로 고도화 필요
                         } else {
                             long offset =
                                 (result != null && result.getRecordMetadata() != null) ? result.getRecordMetadata()
                                     .offset() : -1;
-                            log.info("Kafka 메시지 발행 성공! offset: {}", offset);
+                            log.info("Kafka 예약 메시지 발행 성공! offset: {}", offset);
                         }
                     });
                 return;
 
             } catch (ObjectOptimisticLockingFailureException e) {
                 retryCount++;
-                log.warn("재고 차감 동시성(낙관적 락) 충돌 발생. 재시도 횟수: {}/{}", retryCount, MAX_RETRY_COUNT);
-                if (retryCount >= MAX_RETRY_COUNT) {
-                    throw new IllegalStateException("주문량이 많아 재고 처리에 실패했습니다. 다시 시도해주세요.");
+                log.warn("재고 차감 동시성(낙관적 락) 충돌 발생. 재시도 횟수: {}/{}", retryCount, maxRetryCount);
+                if (retryCount >= maxRetryCount) {
+                    throw new ConcurrencyFailureException();
                 }
-                try {
-                    Thread.sleep(50); // 잠시 대기 후 재시도
-                } catch (InterruptedException ie) {
-                    // 쓰레드 인터럽트 발생 시 플래그를 세우고 루프를 탈출하여 예외를 던지도록 수정
-                    Thread.currentThread().interrupt();
-                    throw new IllegalStateException("재고 처리 대기 중 쓰레드가 강제 종료되었습니다.", ie);
-                }
+                backoff("차감");
             }
         }
     }
@@ -67,7 +72,7 @@ public class StockCommandService {
     // 트랜잭션 내부에서 실행될 순수 비즈니스 로직
     private StockReservedEvent reserveStockInternal(ReserveStockRequest request) {
         Stock stock = stockRepository.findById(request.optionId())
-            .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 재고 옵션입니다."));
+            .orElseThrow(StockNotFoundException::new);
 
         // 1. 도메인 로직을 통한 3중 검증 및 차감
         stock.reserve(request.quantity());
@@ -81,5 +86,66 @@ public class StockCommandService {
             stock.getTotalQuantity(),
             stock.getCurrentDailyStock()
         );
+    }
+
+    //복구로직
+    public void restoreStockWithRetry(RestoreStockRequest request) {
+        int retryCount = 0;
+        while (retryCount < maxRetryCount) {
+            try {
+                // 1. 매 재시도마다 독립된 새로운 트랜잭션을 연다
+                StockRestoredEvent event = transactionTemplate.execute(status -> restoreStockInternal(request));
+
+                // 2. DB 커밋 완료 후 Kafka 발행
+                kafkaTemplate.send(topicStockRestored, request.optionId().toString(), event)
+                    .whenComplete((result, ex) -> {
+                        if (ex != null) {
+                            log.error("Kafka 복구 메시지 발행 실패 (재고 유실 위험)! optionId: {}", request.optionId(), ex);
+                        } else {
+                            long offset =
+                                (result != null && result.getRecordMetadata() != null) ? result.getRecordMetadata()
+                                    .offset() : -1;
+                            log.info("Kafka 복구 메시지 발행 성공! offset: {}", offset);
+                        }
+                    });
+                return;
+
+            } catch (ObjectOptimisticLockingFailureException e) {
+                retryCount++;
+                log.warn("재고 복구 동시성(낙관적 락) 충돌 발생. 재시도 횟수: {}/{}", retryCount, maxRetryCount);
+                if (retryCount >= maxRetryCount) {
+                    throw new ConcurrencyFailureException();
+                }
+                backoff("복구");
+            }
+        }
+    }
+
+    // 트랜잭션 내부에서 실행될 순수 비즈니스 로직
+    private StockRestoredEvent restoreStockInternal(RestoreStockRequest request) {
+        Stock stock = stockRepository.findById(request.optionId())
+            .orElseThrow(StockNotFoundException::new);
+
+        // 1. 도메인 로직: 재고 복구
+        stock.restore(request.quantity());
+
+        // 2. DB 업데이트 (더티 체킹 후 flush)
+        stockRepository.save(stock);
+
+        // 3. Kafka 이벤트 발행용 객체 리턴
+        return new StockRestoredEvent(
+            stock.getOptionId(),
+            stock.getTotalQuantity(),
+            stock.getCurrentDailyStock()
+        );
+    }
+
+    private void backoff(String operationType) {
+        try {
+            Thread.sleep(50);
+        } catch (InterruptedException ie) {
+            Thread.currentThread().interrupt();
+            throw new IllegalStateException("재고 " + operationType + " 대기 중 쓰레드가 강제 종료되었습니다.", ie);
+        }
     }
 }

--- a/src/main/java/com/michelet/inventory/application/StockCommandService.java
+++ b/src/main/java/com/michelet/inventory/application/StockCommandService.java
@@ -8,6 +8,7 @@ import com.michelet.inventory.domain.model.Stock;
 import com.michelet.inventory.domain.repository.StockRepository;
 import com.michelet.inventory.presentation.dto.ReserveStockRequest;
 import com.michelet.inventory.presentation.dto.RestoreStockRequest;
+import jakarta.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -33,6 +34,15 @@ public class StockCommandService {
 
     @Value("${inventory.kafka.topic.restored:stock.restored}")
     private String topicStockRestored;
+
+    // 재시도 횟수 설정 오류 방어 - 최소 1회 실행 보장
+    @PostConstruct
+    public void validateConfig() {
+        if (this.maxRetryCount <= 0) {
+            log.warn("maxRetryCount [{}] 설정이 0 이하입니다. 1로 강제 조정합니다.", this.maxRetryCount);
+            this.maxRetryCount = Math.max(1, this.maxRetryCount);
+        }
+    }
 
     // @Transactional을 제거 - AOP Self-Invocation 방지
     public void reserveStockWithRetry(ReserveStockRequest request) {

--- a/src/main/java/com/michelet/inventory/application/dto/ProductCreatedEvent.java
+++ b/src/main/java/com/michelet/inventory/application/dto/ProductCreatedEvent.java
@@ -11,6 +11,7 @@ public record ProductCreatedEvent(
     UUID restaurantId,
     String name,
     String category,
+    BigDecimal basePrice,
     Map<String, Object> attributes,
     LocalDateTime startAt,
     LocalDateTime endAt,

--- a/src/main/java/com/michelet/inventory/application/dto/ProductCreatedEvent.java
+++ b/src/main/java/com/michelet/inventory/application/dto/ProductCreatedEvent.java
@@ -23,9 +23,8 @@ public record ProductCreatedEvent(
         Objects.requireNonNull(restaurantId, "restaurantId는 필수입니다.");
         Objects.requireNonNull(name, "name은 필수입니다.");
         Objects.requireNonNull(category, "category는 필수입니다.");
-
-        // basePrice 과거 메시지(Null) 호환성 확보 및 음수 검증
-        if (basePrice != null && basePrice.compareTo(BigDecimal.ZERO) < 0) {
+        Objects.requireNonNull(basePrice, "basePrice는 필수입니다.");
+        if (basePrice.compareTo(BigDecimal.ZERO) < 0) {
             throw new IllegalArgumentException("기본 가격은 0원 이상이어야 합니다.");
         }
 

--- a/src/main/java/com/michelet/inventory/application/dto/ProductCreatedEvent.java
+++ b/src/main/java/com/michelet/inventory/application/dto/ProductCreatedEvent.java
@@ -4,6 +4,7 @@ import java.math.BigDecimal;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.UUID;
 
 public record ProductCreatedEvent(
@@ -17,6 +18,21 @@ public record ProductCreatedEvent(
     LocalDateTime endAt,
     List<OptionEventDto> options
 ) {
+    public ProductCreatedEvent {
+        Objects.requireNonNull(productId, "productId는 필수입니다.");
+        Objects.requireNonNull(restaurantId, "restaurantId는 필수입니다.");
+        Objects.requireNonNull(name, "name은 필수입니다.");
+        Objects.requireNonNull(category, "category는 필수입니다.");
+
+        // basePrice 과거 메시지(Null) 호환성 확보 및 음수 검증
+        if (basePrice != null && basePrice.compareTo(BigDecimal.ZERO) < 0) {
+            throw new IllegalArgumentException("기본 가격은 0원 이상이어야 합니다.");
+        }
+
+        attributes = attributes == null ? Map.of() : Map.copyOf(attributes);
+        options = options == null ? List.of() : List.copyOf(options);
+    }
+
     public record OptionEventDto(
         UUID optionId,
         String name,
@@ -24,5 +40,16 @@ public record ProductCreatedEvent(
         Integer totalQuantity,
         Integer currentDailyStock
     ) {
+        public OptionEventDto {
+            Objects.requireNonNull(optionId, "optionId는 필수입니다.");
+            Objects.requireNonNull(name, "옵션명은 필수입니다.");
+            Objects.requireNonNull(addPrice, "addPrice는 필수입니다.");
+            Objects.requireNonNull(totalQuantity, "totalQuantity는 필수입니다.");
+            Objects.requireNonNull(currentDailyStock, "currentDailyStock는 필수입니다.");
+
+            if (totalQuantity < 0 || currentDailyStock < 0) {
+                throw new IllegalArgumentException("재고 수량은 0 이상이어야 합니다.");
+            }
+        }
     }
 }

--- a/src/main/java/com/michelet/inventory/application/dto/StockRestoredEvent.java
+++ b/src/main/java/com/michelet/inventory/application/dto/StockRestoredEvent.java
@@ -1,5 +1,6 @@
 package com.michelet.inventory.application.dto;
 
+import java.util.Objects;
 import java.util.UUID;
 
 public record StockRestoredEvent(
@@ -7,4 +8,14 @@ public record StockRestoredEvent(
     Integer totalQuantity,
     Integer currentDailyStock
 ) {
+    // 컴팩트 생성자
+    public StockRestoredEvent {
+        Objects.requireNonNull(optionId, "optionId는 필수입니다.");
+        Objects.requireNonNull(totalQuantity, "totalQuantity는 필수입니다.");
+        Objects.requireNonNull(currentDailyStock, "currentDailyStock는 필수입니다.");
+
+        if (totalQuantity < 0 || currentDailyStock < 0) {
+            throw new IllegalArgumentException("재고 수량은 0 이상이어야 합니다.");
+        }
+    }
 }

--- a/src/main/java/com/michelet/inventory/application/dto/StockRestoredEvent.java
+++ b/src/main/java/com/michelet/inventory/application/dto/StockRestoredEvent.java
@@ -1,0 +1,10 @@
+package com.michelet.inventory.application.dto;
+
+import java.util.UUID;
+
+public record StockRestoredEvent(
+    UUID optionId,
+    int totalQuantity,
+    int currentDailyStock
+) {
+}

--- a/src/main/java/com/michelet/inventory/application/dto/StockRestoredEvent.java
+++ b/src/main/java/com/michelet/inventory/application/dto/StockRestoredEvent.java
@@ -4,7 +4,7 @@ import java.util.UUID;
 
 public record StockRestoredEvent(
     UUID optionId,
-    int totalQuantity,
-    int currentDailyStock
+    Integer totalQuantity,
+    Integer currentDailyStock
 ) {
 }

--- a/src/main/java/com/michelet/inventory/domain/exception/ConcurrencyFailureException.java
+++ b/src/main/java/com/michelet/inventory/domain/exception/ConcurrencyFailureException.java
@@ -1,0 +1,9 @@
+package com.michelet.inventory.domain.exception;
+
+import com.michelet.common.exception.BusinessException;
+
+public class ConcurrencyFailureException extends BusinessException {
+    public ConcurrencyFailureException() {
+        super(InventoryErrorCode.CONCURRENCY_ERROR);
+    }
+}

--- a/src/main/java/com/michelet/inventory/domain/exception/InventoryErrorCode.java
+++ b/src/main/java/com/michelet/inventory/domain/exception/InventoryErrorCode.java
@@ -10,7 +10,9 @@ public enum InventoryErrorCode implements ErrorCode {
 
     OUT_OF_STOCK(409, "INVENTORY_001", "일일 판매 가능 수량을 초과했습니다."),
     SOLD_OUT(409, "INVENTORY_002", "전체 재고가 모두 소진되었습니다."),
-    MAX_LIMIT_EXCEEDED(400, "INVENTORY_003", "1인당 최대 구매 가능 수량을 초과했습니다.");
+    MAX_LIMIT_EXCEEDED(400, "INVENTORY_003", "1인당 최대 구매 가능 수량을 초과했습니다."),
+    STOCK_NOT_FOUND(404, "INVENTORY_004", "해당 재고 정보를 찾을 수 없습니다."),
+    CONCURRENCY_ERROR(429, "INVENTORY_005", "현재 주문 요청이 많습니다. 잠시 후 다시 시도해주세요.");
 
     private final int httpStatus;
     private final String code;

--- a/src/main/java/com/michelet/inventory/domain/exception/StockNotFoundException.java
+++ b/src/main/java/com/michelet/inventory/domain/exception/StockNotFoundException.java
@@ -1,0 +1,10 @@
+package com.michelet.inventory.domain.exception;
+
+import com.michelet.common.exception.BusinessException;
+
+public class StockNotFoundException extends BusinessException {
+
+    public StockNotFoundException() {
+        super(InventoryErrorCode.STOCK_NOT_FOUND);
+    }
+}

--- a/src/main/java/com/michelet/inventory/domain/model/Stock.java
+++ b/src/main/java/com/michelet/inventory/domain/model/Stock.java
@@ -104,4 +104,17 @@ public class Stock extends BaseEntity implements Persistable<UUID> {
         // createdAt은 DB 저장 후에 채워지므로, 객체 생성 직후엔 version(null)으로 판단하는 것이 더 정확함
         return version == null;
     }
+
+    // 복구 로직
+    public void restore(int quantity) {
+        // 1. 전체 재고 복구: Quantity 객체로 검증. 계산 후, 최종 숫자값만 필드에 대입
+        this.totalQuantity = new Quantity(this.totalQuantity).plus(quantity).value();
+
+        // 2. 일일 재고 복구 (dailyLimit 이내로 제한)
+        int expectedDailyStock = this.currentDailyStock + quantity;
+        int restoredDailyStock = Math.min(expectedDailyStock, this.dailyLimit);
+
+        // 3. 필드 업데이트 (Quantity를 거쳐서 음수 여부 등 최종 검증)
+        this.currentDailyStock = new Quantity(restoredDailyStock).value();
+    }
 }

--- a/src/main/java/com/michelet/inventory/domain/model/Stock.java
+++ b/src/main/java/com/michelet/inventory/domain/model/Stock.java
@@ -107,6 +107,9 @@ public class Stock extends BaseEntity implements Persistable<UUID> {
 
     // 복구 로직
     public void restore(int quantity) {
+        if (quantity <= 0) {
+            throw new IllegalArgumentException("복구 수량은 0보다 커야 합니다.");
+        }
         // 1. 전체 재고 복구: Quantity 객체로 검증. 계산 후, 최종 숫자값만 필드에 대입
         this.totalQuantity = new Quantity(this.totalQuantity).plus(quantity).value();
 

--- a/src/main/java/com/michelet/inventory/domain/model/vo/Quantity.java
+++ b/src/main/java/com/michelet/inventory/domain/model/vo/Quantity.java
@@ -12,4 +12,14 @@ public record Quantity(Integer value) {
             throw new IllegalArgumentException("수량은 0개 이상이어야 합니다.");
         }
     }
+
+    // 새로운 수량을 더한 Quantity 객체를 반환하는 메서드
+    public Quantity plus(int amount) {
+        return new Quantity(this.value + amount);
+    }
+
+    // 값을 Integer로 꺼내주는 편의 메서드
+    public int toInt() {
+        return this.value;
+    }
 }

--- a/src/main/java/com/michelet/inventory/presentation/InternalStockController.java
+++ b/src/main/java/com/michelet/inventory/presentation/InternalStockController.java
@@ -3,6 +3,7 @@ package com.michelet.inventory.presentation;
 import com.michelet.common.response.ApiResponse;
 import com.michelet.inventory.application.StockCommandService;
 import com.michelet.inventory.presentation.dto.ReserveStockRequest;
+import com.michelet.inventory.presentation.dto.RestoreStockRequest;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -42,6 +43,21 @@ public class InternalStockController {
         }
 
         stockCommandService.reserveStockWithRetry(request);
+
+        return ResponseEntity.ok(ApiResponse.ok(null));
+    }
+
+    //FIXME 임시적용 - common webmvc 수정되면 여기도 수정
+    @PostMapping("/restore")
+    public ResponseEntity<ApiResponse<Void>> restoreStock(
+        @RequestHeader(value = "X-User-Role", required = true) String userRole,
+        @RequestBody @Valid RestoreStockRequest request
+    ) {
+        if (!"SYSTEM".equals(userRole)) {
+            throw new ResponseStatusException(HttpStatus.FORBIDDEN, "시스템 내부 통신만 접근 가능합니다.");
+        }
+
+        stockCommandService.restoreStockWithRetry(request);
 
         return ResponseEntity.ok(ApiResponse.ok(null));
     }

--- a/src/main/java/com/michelet/inventory/presentation/dto/ReserveStockRequest.java
+++ b/src/main/java/com/michelet/inventory/presentation/dto/ReserveStockRequest.java
@@ -6,6 +6,7 @@ import java.util.UUID;
 
 public record ReserveStockRequest(
     @NotNull UUID optionId,
-    @NotNull @Min(1) Integer quantity
+    @NotNull @Min(1) Integer quantity,
+    UUID reservationId   // 멱등키 — TODO 추후 중복 차감 방지 로직에서 활용 예정 (그땐 @NotNull)
 ) {
 }

--- a/src/main/java/com/michelet/inventory/presentation/dto/RestoreStockRequest.java
+++ b/src/main/java/com/michelet/inventory/presentation/dto/RestoreStockRequest.java
@@ -6,6 +6,7 @@ import java.util.UUID;
 
 public record RestoreStockRequest(
     @NotNull UUID optionId,
-    @Positive int quantity
+    @Positive int quantity,
+    UUID reservationId   // 멱등키 — TODO 추후 중복 복구 방지 로직에서 활용 예정 (그땐 @NotNull)
 ) {
 }

--- a/src/main/java/com/michelet/inventory/presentation/dto/RestoreStockRequest.java
+++ b/src/main/java/com/michelet/inventory/presentation/dto/RestoreStockRequest.java
@@ -1,0 +1,11 @@
+package com.michelet.inventory.presentation.dto;
+
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+import java.util.UUID;
+
+public record RestoreStockRequest(
+    @NotNull UUID optionId,
+    @Positive int quantity
+) {
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -13,3 +13,12 @@ spring:
 
 server:
     port: 19900
+
+inventory:
+    retry:
+        max-count: 3
+    kafka:
+        topic:
+            product-created: "product.created"
+            reserved: "stock.reserved"
+            restored: "stock.restored"

--- a/src/test/java/com/michelet/inventory/application/ProductCommandServiceTest.java
+++ b/src/test/java/com/michelet/inventory/application/ProductCommandServiceTest.java
@@ -6,6 +6,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
@@ -26,6 +27,8 @@ import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -66,6 +69,11 @@ class ProductCommandServiceTest {
     @Captor
     private ArgumentCaptor<List<Stock>> stocksCaptor;
 
+    @BeforeEach
+    void setUp() {
+        ReflectionTestUtils.setField(productCommandService, "topicProductCreated", "product.created");
+    }
+
     @Test
     @DisplayName("성공: 상품 등록 시 모든 도메인 모델(상품/전시/옵션/재고)이 올바른 값으로 저장소에 전달되어야 한다")
     void createProductUnitTest() {
@@ -105,11 +113,11 @@ class ProductCommandServiceTest {
         });
 
         // 3. KafkaTemplate 모킹: send 호출 시 빈 가짜 영수증(CompletableFuture?) 반환
-        java.util.concurrent.CompletableFuture<org.springframework.kafka.support.SendResult<String, Object>> mockFuture
-            = java.util.concurrent.CompletableFuture.completedFuture(
-            new org.springframework.kafka.support.SendResult<>(null, null)
-        );
-        given(kafkaTemplate.send(anyString(), any(), any())).willReturn(mockFuture);
+        CompletableFuture<org.springframework.kafka.support.SendResult<String, Object>> mockFuture
+            = CompletableFuture.completedFuture(new org.springframework.kafka.support.SendResult<>(null, null));
+
+        // lenient()를 추가 - Mockito의 엄격한 Stubbing 검사(PotentialStubbingProblem) 유연하게 통과시킴
+        lenient().when(kafkaTemplate.send(anyString(), anyString(), any())).thenReturn(mockFuture);
 
         // when
         ProductResult result = productCommandService.createProduct(command);

--- a/src/test/java/com/michelet/inventory/application/ProductCommandServiceTest.java
+++ b/src/test/java/com/michelet/inventory/application/ProductCommandServiceTest.java
@@ -146,6 +146,8 @@ class ProductCommandServiceTest {
         assertThat(capturedEvent.name()).isEqualTo("미슐랭 밀키트 세트");
         assertThat(capturedEvent.category()).isEqualTo(ProductCategory.MEALKIT.name());
 
+        assertThat(capturedEvent.basePrice()).isEqualByComparingTo(command.basePrice());
+
         assertThat(result).isNotNull();
         assertThat(result.productId()).isNotNull();
         assertThat(result.productId()).isEqualTo(savedProduct.getId());

--- a/src/test/java/com/michelet/inventory/application/StockCommandServiceTest.java
+++ b/src/test/java/com/michelet/inventory/application/StockCommandServiceTest.java
@@ -214,25 +214,36 @@ class StockCommandServiceTest {
     }
 
     @Test
-    @DisplayName("성공: 재고 복구 경로 정상 동작 및 Kafka 발행 테스트")
+    @DisplayName("성공: 재고 복구 경로 정상 동작 및 Kafka 발행 테스트 (total/daily 모두 검증)")
     void restoreStock_Success() {
         UUID optionId = UUID.randomUUID();
+        // 1. 초기 재고 100개, 일일 재고 50개 생성
         Stock stock = Stock.create(optionId, 100, 50, 10);
+
+        // 2. 소비된 상태를 시뮬레이션하기 위해 미리 2개를 차감 (total: 98, daily: 48)
+        stock.reserve(2);
+
+        // 3. 다시 2개를 복구해 달라는 요청
         RestoreStockRequest request = new RestoreStockRequest(optionId, 2, null);
 
         given(stockRepository.findById(optionId)).willReturn(Optional.of(stock));
         given(kafkaTemplate.send(eq("stock.restored"), eq(optionId.toString()), any(StockRestoredEvent.class)))
             .willReturn(CompletableFuture.completedFuture(null));
 
+        // when
         stockCommandService.restoreStockWithRetry(request);
 
+        // then
         verify(stockRepository, times(1)).save(any(Stock.class));
         verify(kafkaTemplate, times(1)).send(eq("stock.restored"), eq(optionId.toString()),
             restoredEventCaptor.capture());
 
         StockRestoredEvent event = restoredEventCaptor.getValue();
         assertThat(event.optionId()).isEqualTo(optionId);
-        assertThat(event.totalQuantity()).isEqualTo(102);
+
+        // totalQuantity와 currentDailyStock이 모두 100과 50으로 정상 복구되었는지 검증
+        assertThat(event.totalQuantity()).isEqualTo(100);
+        assertThat(event.currentDailyStock()).isEqualTo(50);
     }
 
     @Test

--- a/src/test/java/com/michelet/inventory/application/StockCommandServiceTest.java
+++ b/src/test/java/com/michelet/inventory/application/StockCommandServiceTest.java
@@ -78,7 +78,7 @@ class StockCommandServiceTest {
         // given
         UUID optionId = UUID.randomUUID();
         Stock stock = Stock.create(optionId, 100, 50, 10);
-        ReserveStockRequest request = new ReserveStockRequest(optionId, 2);
+        ReserveStockRequest request = new ReserveStockRequest(optionId, 2, null);
 
         given(stockRepository.findById(optionId)).willReturn(Optional.of(stock));
         given(kafkaTemplate.send(eq("stock.reserved"), eq(optionId.toString()), any(StockReservedEvent.class)))
@@ -103,7 +103,7 @@ class StockCommandServiceTest {
         // given
         UUID optionId = UUID.randomUUID();
         Stock stock = Stock.create(optionId, 100, 1, 10); // 일일 재고 1개
-        ReserveStockRequest request = new ReserveStockRequest(optionId, 2); // 2개 요청
+        ReserveStockRequest request = new ReserveStockRequest(optionId, 2, null); // 2개 요청
 
         given(stockRepository.findById(optionId)).willReturn(Optional.of(stock));
 
@@ -122,7 +122,7 @@ class StockCommandServiceTest {
         // given
         UUID optionId = UUID.randomUUID();
         Stock stock = Stock.create(optionId, 1, 50, 10); // 전체 재고 1개
-        ReserveStockRequest request = new ReserveStockRequest(optionId, 2); // 2개 요청
+        ReserveStockRequest request = new ReserveStockRequest(optionId, 2, null); // 2개 요청
 
         given(stockRepository.findById(optionId)).willReturn(Optional.of(stock));
 
@@ -140,7 +140,7 @@ class StockCommandServiceTest {
         // given
         UUID optionId = UUID.randomUUID();
         Stock stock = Stock.create(optionId, 100, 50, 1); // 1인당 1개 제한
-        ReserveStockRequest request = new ReserveStockRequest(optionId, 2); // 2개 요청
+        ReserveStockRequest request = new ReserveStockRequest(optionId, 2, null); //2개 요청
 
         given(stockRepository.findById(optionId)).willReturn(Optional.of(stock));
 
@@ -157,7 +157,7 @@ class StockCommandServiceTest {
     void reserveStock_Retry_Success() {
         // given
         UUID optionId = UUID.randomUUID();
-        ReserveStockRequest request = new ReserveStockRequest(optionId, 2);
+        ReserveStockRequest request = new ReserveStockRequest(optionId, 2, null);
 
         // DB에서 최신 데이터를 다시 읽어오는 동작을 시뮬레이션 (매 호출마다 새로운 Stock 객체 반환)
         given(stockRepository.findById(optionId)).willAnswer(invocation ->
@@ -194,7 +194,7 @@ class StockCommandServiceTest {
     void reserveStock_Retry_Fail_MaxAttempts() {
         // given
         UUID optionId = UUID.randomUUID();
-        ReserveStockRequest request = new ReserveStockRequest(optionId, 2);
+        ReserveStockRequest request = new ReserveStockRequest(optionId, 2, null);
 
         given(stockRepository.findById(optionId)).willAnswer(invocation ->
             Optional.of(Stock.create(optionId, 100, 50, 10))

--- a/src/test/java/com/michelet/inventory/application/StockCommandServiceTest.java
+++ b/src/test/java/com/michelet/inventory/application/StockCommandServiceTest.java
@@ -11,6 +11,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 
 import com.michelet.inventory.application.dto.StockReservedEvent;
+import com.michelet.inventory.domain.exception.ConcurrencyFailureException;
 import com.michelet.inventory.domain.exception.MaxLimitExceededException;
 import com.michelet.inventory.domain.exception.OutOfStockException;
 import com.michelet.inventory.domain.exception.SoldOutException;
@@ -31,6 +32,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.orm.ObjectOptimisticLockingFailureException;
+import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.transaction.support.TransactionCallback;
 import org.springframework.transaction.support.TransactionTemplate;
 
@@ -59,6 +61,9 @@ class StockCommandServiceTest {
             TransactionCallback<StockReservedEvent> action = invocation.getArgument(0);
             return action.doInTransaction(null);
         });
+        ReflectionTestUtils.setField(stockCommandService, "maxRetryCount", 3);
+        ReflectionTestUtils.setField(stockCommandService, "topicStockReserved", "stock.reserved");
+        ReflectionTestUtils.setField(stockCommandService, "topicStockRestored", "stock.restored");
     }
 
     @Test
@@ -193,10 +198,9 @@ class StockCommandServiceTest {
         given(stockRepository.save(any(Stock.class)))
             .willThrow(new ObjectOptimisticLockingFailureException(Stock.class.getName(), optionId));
 
-        // when & then: 3번 시도 후 IllegalStateException 발생 검증
+        // when & then: 3번 시도 후 ConcurrencyFailureException
         assertThatThrownBy(() -> stockCommandService.reserveStockWithRetry(request))
-            .isInstanceOf(IllegalStateException.class)
-            .hasMessageContaining("주문량이 많아 재고 처리에 실패했습니다");
+            .isInstanceOf(ConcurrencyFailureException.class);
 
         verify(stockRepository, times(3)).findById(optionId);
         verify(stockRepository, times(3)).save(any(Stock.class)); // 정확히 3번 시도됨

--- a/src/test/java/com/michelet/inventory/application/StockCommandServiceTest.java
+++ b/src/test/java/com/michelet/inventory/application/StockCommandServiceTest.java
@@ -11,13 +11,16 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 
 import com.michelet.inventory.application.dto.StockReservedEvent;
+import com.michelet.inventory.application.dto.StockRestoredEvent;
 import com.michelet.inventory.domain.exception.ConcurrencyFailureException;
 import com.michelet.inventory.domain.exception.MaxLimitExceededException;
 import com.michelet.inventory.domain.exception.OutOfStockException;
 import com.michelet.inventory.domain.exception.SoldOutException;
+import com.michelet.inventory.domain.exception.StockNotFoundException;
 import com.michelet.inventory.domain.model.Stock;
 import com.michelet.inventory.domain.repository.StockRepository;
 import com.michelet.inventory.presentation.dto.ReserveStockRequest;
+import com.michelet.inventory.presentation.dto.RestoreStockRequest;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
@@ -55,10 +58,13 @@ class StockCommandServiceTest {
     @Captor
     private ArgumentCaptor<StockReservedEvent> eventCaptor;
 
+    @Captor
+    private ArgumentCaptor<StockRestoredEvent> restoredEventCaptor;
+
     @BeforeEach
     void setUp() {
         given(transactionTemplate.execute(any())).willAnswer(invocation -> {
-            TransactionCallback<StockReservedEvent> action = invocation.getArgument(0);
+            TransactionCallback<?> action = invocation.getArgument(0);
             return action.doInTransaction(null);
         });
         ReflectionTestUtils.setField(stockCommandService, "maxRetryCount", 3);
@@ -207,4 +213,62 @@ class StockCommandServiceTest {
         verifyNoInteractions(kafkaTemplate); // 실패했으므로 카프카 메시지 발행 안 됨
     }
 
+    @Test
+    @DisplayName("성공: 재고 복구 경로 정상 동작 및 Kafka 발행 테스트")
+    void restoreStock_Success() {
+        UUID optionId = UUID.randomUUID();
+        Stock stock = Stock.create(optionId, 100, 50, 10);
+        RestoreStockRequest request = new RestoreStockRequest(optionId, 2, null);
+
+        given(stockRepository.findById(optionId)).willReturn(Optional.of(stock));
+        given(kafkaTemplate.send(eq("stock.restored"), eq(optionId.toString()), any(StockRestoredEvent.class)))
+            .willReturn(CompletableFuture.completedFuture(null));
+
+        stockCommandService.restoreStockWithRetry(request);
+
+        verify(stockRepository, times(1)).save(any(Stock.class));
+        verify(kafkaTemplate, times(1)).send(eq("stock.restored"), eq(optionId.toString()),
+            restoredEventCaptor.capture());
+
+        StockRestoredEvent event = restoredEventCaptor.getValue();
+        assertThat(event.optionId()).isEqualTo(optionId);
+        assertThat(event.totalQuantity()).isEqualTo(102);
+    }
+
+    @Test
+    @DisplayName("재시도 성공: 복구 시 낙관적 락 충돌이 발생해도 재시도하여 성공한다.")
+    void restoreStock_Retry_Success() {
+        UUID optionId = UUID.randomUUID();
+        RestoreStockRequest request = new RestoreStockRequest(optionId, 2, null);
+
+        given(stockRepository.findById(optionId)).willAnswer(invocation ->
+            Optional.of(Stock.create(optionId, 100, 50, 10))
+        );
+
+        given(stockRepository.save(any(Stock.class)))
+            .willThrow(new ObjectOptimisticLockingFailureException(Stock.class.getName(), optionId))
+            .willReturn(null); // 두 번째 시도 성공
+
+        given(kafkaTemplate.send(anyString(), anyString(), any()))
+            .willReturn(CompletableFuture.completedFuture(null));
+
+        stockCommandService.restoreStockWithRetry(request);
+
+        verify(stockRepository, times(2)).findById(optionId);
+        verify(stockRepository, times(2)).save(any(Stock.class));
+    }
+
+    @Test
+    @DisplayName("실패: 재고 복구 시 존재하지 않는 옵션 예외")
+    void restoreStock_Fail_NotFound() {
+        UUID optionId = UUID.randomUUID();
+        RestoreStockRequest request = new RestoreStockRequest(optionId, 5, null);
+
+        given(stockRepository.findById(optionId)).willReturn(Optional.empty());
+
+        assertThatThrownBy(() -> stockCommandService.restoreStockWithRetry(request))
+            .isInstanceOf(StockNotFoundException.class);
+
+        verifyNoInteractions(kafkaTemplate);
+    }
 }

--- a/src/test/java/com/michelet/inventory/application/StockConcurrencyIntegrationTest.java
+++ b/src/test/java/com/michelet/inventory/application/StockConcurrencyIntegrationTest.java
@@ -95,7 +95,7 @@ class StockConcurrencyIntegrationTest {
         // 성공한 횟수를 안전하게 카운트하기 위한 변수
         AtomicInteger successCount = new AtomicInteger();
 
-        ReserveStockRequest request = new ReserveStockRequest(testOptionId, 1);
+        ReserveStockRequest request = new ReserveStockRequest(testOptionId, 1, null);
 
         // when
         for (int i = 0; i < threadCount; i++) {

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -38,3 +38,12 @@ spring:
 jwt:
     secret: ${JWT_SECRET:michelet-secret-key-for-authentication}
 
+inventory:
+    retry:
+        max-count: 3
+    kafka:
+        topic:
+            product-created: "product.created"
+            reserved: "stock.reserved"
+            restored: "stock.restored"
+


### PR DESCRIPTION
## 📝 작업 내용
> 이번 PR에서 작업한 내용을 설명해주세요.
- 카탈로그 서비스로 전송되는 상품 등록 카프카 이벤트(`ProductCreatedEvent`)에 누락되었던 `basePrice` 속성을 추가
- 결제 실패/취소 시 깎였던 재고를 원상 복구하는 도메인 로직(`Stock.restore`)과 내부 API(`/internal/stocks/restore`)를 구현

## 🚀 주요 변경 사항
> 완료한 이슈 번호 \
> Close #11   \
> 관련된 이슈 번호 (닫고 싶지 않은 경우) \
> Related to # 

## ✅ 자체 체크리스트 (필수)
- [x] `./gradlew build` 실행 결과 정상 (인증샷 첨부)
- [x] IntelliJ HTTP Client 테스트 완료 (인증샷 첨부)
- [x] 팀 내 컨벤션 준수 및 불필요한 로그, import 제거
- [x] 중요한 변경 사항이 팀에 공유되었는지

## 📸 테스트 인증샷
> 빌드 결과 및 IntelliJ HTTP Client 실행 화면을 여기에 첨부해 주세요.
<img width="1072" height="403" alt="스크린샷 2026-05-03 오후 7 21 23" src="https://github.com/user-attachments/assets/868be303-cafc-4289-bb22-ba5ea06cbe7a" />
<img width="1077" height="398" alt="스크린샷 2026-05-03 오후 7 21 30" src="https://github.com/user-attachments/assets/8d8ad059-02eb-42d3-ae7f-d5c959a2a882" />


## 💬 리뷰어 전달사항 (선택)
> 특별히 봐주었으면 하는 부분이나 논의가 필요한 점을 적어주세요.

- 재고 차감/복구 시 `reservationId`를 통한 멱등성 보장 로직은 추후 시스템 고도화 단계에서 추가할 예정이므로 현재 DTO에는 포함하지 않았습니다...!

<br>

---
## 📎 참고 자료

> 관련 문서, 레퍼런스 링크 등이 있다면 여기에 첨부해주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 재고 복구(restore) API 및 복구 플로우가 추가되었습니다.
  * 상품 이벤트에 기본 가격(base price) 정보가 포함됩니다.
  * 예약/복구 요청에 아이디엠포턴시(reservationId) 필드가 도입되었습니다.

* **Improvements**
  * 재시도(backoff) 로직이 통합·강화되어 동시성 처리 안정성이 향상되었습니다.
  * Kafka 토픽명과 재시도 횟수 등 구성이 외부 설정으로 이전되어 운영 유연성이 증가했습니다.
  * 이벤트/페이로드 입력 검증이 강화되었습니다.

* **Bug Fixes**
  * 재고 미존재와 동시성 충돌에 대한 명확한 오류 코드 및 예외 처리가 추가되었습니다.

* **Tests**
  * 관련 단위·통합 테스트가 확장 및 보강되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->