### PR TITLE
Feat/13 - 전시 상태 갱신 및 일일 재고 초기화 스케줄러 구현

### DIFF
--- a/api-test/inventory.http
+++ b/api-test/inventory.http
@@ -172,6 +172,7 @@ X-User-Role: SYSTEM
 ### 5. [Internal] 정시 전시 상태 강제 갱신 트리거
 POST http://{{host}}:{{inventoryPort}}/internal/scheduler/trigger-exhibition
 Content-Type: application/json
+X-User-Role: SYSTEM
 
 > {%
     client.test("전시 상태 스케줄러 트리거 확인", function () {
@@ -182,6 +183,7 @@ Content-Type: application/json
 ### 6. [Internal] 일일 재고 강제 리셋 트리거
 POST http://{{host}}:{{inventoryPort}}/internal/scheduler/trigger-stock
 Content-Type: application/json
+X-User-Role: SYSTEM
 
 > {%
     client.test("재고 리셋 스케줄러 트리거 확인", function () {

--- a/api-test/inventory.http
+++ b/api-test/inventory.http
@@ -36,7 +36,7 @@ Content-Type: application/json
 %}
 
 
-### 2. [Admin] 상품 등록 (RDB 저장 및 product.created 카프카 발행)
+### 2-1. 상품 등록 (RDB 저장 및 product.created 카프카 발행)
 POST http://{{host}}:{{gatewayPort}}/api/v1/products
 Content-Type: application/json
 Authorization: Bearer {{auth_token}}
@@ -102,6 +102,54 @@ Authorization: Bearer {{auth_token}}
     }
 %}
 
+### 2-2. 전시 스케줄러 테스트용 '기간 만료' 상품 등록
+# (endAt이 과거이므로 생성 후 스케줄러 돌리면 HIDDEN으로 변해야 함)
+POST http://{{host}}:{{gatewayPort}}/api/v1/products
+Content-Type: application/json
+Authorization: Bearer {{auth_token}}
+
+{
+    "restaurantId": "550e8400-e29b-41d4-a716-446655440000",
+    "name": "기간 만료 코스 (전시 스케줄러 테스트용)",
+    "category": "MEALKIT",
+    "basePrice": 100000,
+    "attributes": {},
+    "exhibition": {
+        "startAt": "2020-01-01T00:00:00",
+        "endAt": "2023-12-31T23:59:59"
+    },
+    "options": [
+        {
+            "name": "기본",
+            "addPrice": 0,
+            "totalQuantity": 100,
+            "dailyLimit": 20,
+            "maxLimit": 5
+        }
+    ]
+}
+
+> {%
+    // 1. 응답 성공 여부 확인
+    if (response.status >= 200 && response.status < 300 && response.body && response.body.data) {
+        var data = response.body.data;
+
+        // 2. Product ID 저장 및 로그
+        if (data.productId) {
+            client.global.set("expired_product_id", data.productId);
+            client.log("[성공] 저장된 기간 만료 물품 아이디: " + data.productId);
+        } else {
+            client.log("[경고] productId가 응답 데이터에 없습니다.");
+        }
+    } else {
+        // 에러 발생 시 로그
+        client.log("[에러] API 요청 실패 또는 데이터가 없습니다. (Status: " + response.status + ")");
+        if (response.body && response.body.message) {
+            client.log("상세: " + response.body.message);
+        }
+    }
+%}
+
 
 ### 3. [Internal] 재고 차감/선점 (RDB 차감 및 stock.reserved 카프카 발행)
 POST http://{{host}}:{{inventoryPort}}/internal/stocks/reserve
@@ -135,4 +183,24 @@ X-User-Role: SYSTEM
         client.assert(response.status === 200, "재고 복구에 실패했습니다.");
     });
     client.log("재고 복구 테스트 대상 공유 옵션 아이디: " + client.global.get("shared_option_id"));
+%}
+
+### 5. [Internal] 정시 전시 상태 강제 갱신 트리거
+POST http://{{host}}:{{inventoryPort}}/internal/scheduler/trigger-exhibition
+Content-Type: application/json
+
+> {%
+    client.test("전시 상태 스케줄러 트리거 확인", function () {
+        client.assert(response.status === 200, "전시 상태 스케줄러 호출에 실패했습니다.");
+    });
+%}
+
+### 6. [Internal] 일일 재고 강제 리셋 트리거
+POST http://{{host}}:{{inventoryPort}}/internal/scheduler/trigger-stock
+Content-Type: application/json
+
+> {%
+    client.test("재고 리셋 스케줄러 트리거 확인", function () {
+        client.assert(response.status === 200, "재고 리셋 스케줄러 호출에 실패했습니다.");
+    });
 %}

--- a/api-test/inventory.http
+++ b/api-test/inventory.http
@@ -26,13 +26,16 @@ Content-Type: application/json
 }
 
 > {%
-    var token = response.body.data.accessToken;
-    client.global.set("auth_token", token);
+    client.test("로그인 성공 확인", function () {
+        client.assert(response.status >= 200 && response.status < 300, "로그인 실패");
+        client.assert(response.body.data !== undefined, "응답 데이터 누락");
 
-    client.log("=======================================");
-    client.log("[로그인 성공]");
-    client.log("저장된 auth_token: " + token);
-    client.log("=======================================");
+        var token = response.body.data.accessToken;
+        client.global.set("auth_token", token);
+        client.log("=======================================");
+        client.log("[로그인 성공] 저장된 auth_token: " + token);
+        client.log("=======================================");
+    });
 %}
 
 
@@ -72,38 +75,27 @@ Authorization: Bearer {{auth_token}}
 }
 
 > {%
-    // 1. 응답 성공 여부 확인
-    if (response.status >= 200 && response.status < 300 && response.body && response.body.data) {
+    client.test("상품 등록 성공", function () {
+        client.assert(response.status >= 200 && response.status < 300, "상품 등록 실패");
+        client.assert(response.body && response.body.data, "응답 data 누락");
+
         var data = response.body.data;
+        client.assert(data.productId, "productId 누락");
+        client.global.set("shared_product_id", data.productId);
+        client.log("[성공] 저장된 공유 물품 아이디: " + data.productId);
 
-        // 2. Product ID 저장 및 로그
-        if (data.productId) {
-            client.global.set("shared_product_id", data.productId);
-            client.log("[성공] 저장된 공유 물품 아이디: " + data.productId);
-        } else {
-            client.log("[경고] productId가 응답 데이터에 없습니다.");
-        }
-
-        // 3. Options 안전하게 추출
-        if (data.options && data.options.length > 0) {
+        // optionId가 정의되어 있는지 확실히 검증 후 할당
+        if (data.options && data.options.length > 0 && data.options[0].optionId) {
             var optionId = data.options[0].optionId;
             client.global.set("shared_option_id", optionId);
             client.log("[성공] 저장된 공유 옵션 아이디: " + optionId);
         } else {
-            client.log("[경고] options 데이터가 비어있습니다.");
+            client.assert(false, "response.data.options[0].optionId 누락");
         }
-
-    } else {
-        // 에러 발생 시 로그
-        client.log("[에러] API 요청 실패 또는 데이터가 없습니다. (Status: " + response.status + ")");
-        if (response.body && response.body.message) {
-            client.log("상세: " + response.body.message);
-        }
-    }
+    });
 %}
 
 ### 2-2. 전시 스케줄러 테스트용 '기간 만료' 상품 등록
-# (endAt이 과거이므로 생성 후 스케줄러 돌리면 HIDDEN으로 변해야 함)
 POST http://{{host}}:{{gatewayPort}}/api/v1/products
 Content-Type: application/json
 Authorization: Bearer {{auth_token}}
@@ -130,24 +122,16 @@ Authorization: Bearer {{auth_token}}
 }
 
 > {%
-    // 1. 응답 성공 여부 확인
-    if (response.status >= 200 && response.status < 300 && response.body && response.body.data) {
-        var data = response.body.data;
+    client.test("기간 만료 상품 등록 확인", function () {
+        client.assert(response.status >= 200 && response.status < 300, "기간 만료 상품 등록 API 실패");
+        client.assert(response.body && response.body.data, "데이터 본문 누락");
 
-        // 2. Product ID 저장 및 로그
-        if (data.productId) {
-            client.global.set("expired_product_id", data.productId);
-            client.log("[성공] 저장된 기간 만료 물품 아이디: " + data.productId);
-        } else {
-            client.log("[경고] productId가 응답 데이터에 없습니다.");
-        }
-    } else {
-        // 에러 발생 시 로그
-        client.log("[에러] API 요청 실패 또는 데이터가 없습니다. (Status: " + response.status + ")");
-        if (response.body && response.body.message) {
-            client.log("상세: " + response.body.message);
-        }
-    }
+        var data = response.body.data;
+        client.assert(data.productId, "productId 누락");
+
+        client.global.set("expired_product_id", data.productId);
+        client.log("[성공] 저장된 기간 만료 물품 아이디: " + data.productId);
+    });
 %}
 
 
@@ -164,8 +148,8 @@ X-User-Role: SYSTEM
 > {%
     client.test("재고 선점 성공 확인", function () {
         client.assert(response.status === 200, "재고 선점에 실패했습니다.");
+        client.log("재고 선점 테스트 대상 공유 옵션 아이디: " + client.global.get("shared_option_id"));
     });
-    client.log("재고 선점 테스트 대상 공유 옵션 아이디: " + client.global.get("shared_option_id"));
 %}
 
 ### 4. [Internal] 재고 복구 (결제 실패 시 RDB 복구 및 stock.restored 카프카 발행)
@@ -181,8 +165,8 @@ X-User-Role: SYSTEM
 > {%
     client.test("재고 복구 성공 확인", function () {
         client.assert(response.status === 200, "재고 복구에 실패했습니다.");
+        client.log("재고 복구 테스트 대상 공유 옵션 아이디: " + client.global.get("shared_option_id"));
     });
-    client.log("재고 복구 테스트 대상 공유 옵션 아이디: " + client.global.get("shared_option_id"));
 %}
 
 ### 5. [Internal] 정시 전시 상태 강제 갱신 트리거

--- a/src/main/java/com/michelet/inventory/InventoryServiceApplication.java
+++ b/src/main/java/com/michelet/inventory/InventoryServiceApplication.java
@@ -5,9 +5,9 @@ import static org.springframework.data.web.config.EnableSpringDataWebSupport.Pag
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.web.config.EnableSpringDataWebSupport;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
-//TODO 일일재고복구
-//@EnableScheduling
+@EnableScheduling
 @EnableSpringDataWebSupport(pageSerializationMode = VIA_DTO)
 @SpringBootApplication
 public class InventoryServiceApplication {

--- a/src/main/java/com/michelet/inventory/application/ExhibitionSchedulerService.java
+++ b/src/main/java/com/michelet/inventory/application/ExhibitionSchedulerService.java
@@ -5,6 +5,7 @@ import com.michelet.inventory.domain.model.Product;
 import com.michelet.inventory.domain.model.ProductStatus;
 import com.michelet.inventory.domain.repository.ProductRepository;
 import java.time.LocalDateTime;
+import java.time.ZoneId;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -14,6 +15,8 @@ import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
 
 @Slf4j
 @Service
@@ -24,6 +27,7 @@ public class ExhibitionSchedulerService {
     private final KafkaTemplate<String, Object> kafkaTemplate;
 
     private static final int CHUNK_SIZE = 100;
+    private static final ZoneId SEOUL_ZONE = ZoneId.of("Asia/Seoul");
 
     @Value("${inventory.kafka.topic.status-changed:product.status-changed}")
     private String topicStatusChanged;
@@ -32,7 +36,7 @@ public class ExhibitionSchedulerService {
     @Scheduled(cron = "0 0 * * * *", zone = "Asia/Seoul") // 매 정시(0분 0초)마다 실행
     public void updateExhibitionStatus() {
         log.info("정시 전시 상태 변경 스케줄러 시작...");
-        LocalDateTime now = LocalDateTime.now();
+        LocalDateTime now = LocalDateTime.now(SEOUL_ZONE);
 
         processOpeningProducts(now);
         processClosingProducts(now);
@@ -41,33 +45,46 @@ public class ExhibitionSchedulerService {
     }
 
     private void processOpeningProducts(LocalDateTime now) {
-        int page = 0;
         Slice<Product> slice;
         do {
-            slice = productRepository.findProductsToOpen(now, PageRequest.of(page, CHUNK_SIZE));
+            // 변경된 데이터는 다음 조회(status='HIDDEN')에서 제외되므로 페이지넘버를 0으로 고정함
+            slice = productRepository.findProductsToOpen(now, PageRequest.of(0, CHUNK_SIZE));
             for (Product product : slice.getContent()) {
                 product.changeStatus(ProductStatus.ACTIVE);
-                publishStatusChangeEvent(product);
+                publishStatusChangeEventAfterCommit(product); // 트랜잭션 커밋 후 발행
             }
-            page++;
         } while (slice.hasNext());
     }
 
     private void processClosingProducts(LocalDateTime now) {
-        int page = 0;
         Slice<Product> slice;
         do {
-            slice = productRepository.findProductsToClose(now, PageRequest.of(page, CHUNK_SIZE));
+            // 변경된 데이터는 다음 조회(status='ACTIVE')에서 제외되므로 페이지넘버를 0으로 고정함
+            slice = productRepository.findProductsToClose(now, PageRequest.of(0, CHUNK_SIZE));
             for (Product product : slice.getContent()) {
                 product.changeStatus(ProductStatus.HIDDEN);
-                publishStatusChangeEvent(product);
+                publishStatusChangeEventAfterCommit(product); // 트랜잭션 커밋 후 발행
             }
-            page++;
         } while (slice.hasNext());
     }
 
-    private void publishStatusChangeEvent(Product product) {
+    // DB 커밋 성공 시에만 카프카로 이벤트 발행 보장
+    private void publishStatusChangeEventAfterCommit(Product product) {
         ProductStatusChangedEvent event = new ProductStatusChangedEvent(product.getId(), product.getStatus().name());
+
+        if (TransactionSynchronizationManager.isSynchronizationActive()) {
+            TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+                @Override
+                public void afterCommit() {
+                    sendKafkaEvent(product, event);
+                }
+            });
+        } else {
+            sendKafkaEvent(product, event);
+        }
+    }
+
+    private void sendKafkaEvent(Product product, ProductStatusChangedEvent event) {
         kafkaTemplate.send(topicStatusChanged, product.getId().toString(), event)
             .whenComplete((result, ex) -> {
                 if (ex != null) {

--- a/src/main/java/com/michelet/inventory/application/ExhibitionSchedulerService.java
+++ b/src/main/java/com/michelet/inventory/application/ExhibitionSchedulerService.java
@@ -8,12 +8,15 @@ import java.time.LocalDateTime;
 import java.time.ZoneId;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Lazy;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Slice;
 import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.support.TransactionSynchronization;
 import org.springframework.transaction.support.TransactionSynchronizationManager;
@@ -26,13 +29,18 @@ public class ExhibitionSchedulerService {
     private final ProductRepository productRepository;
     private final KafkaTemplate<String, Object> kafkaTemplate;
 
+    // Spring AOP의 프록시를 타기 위한 자기 자신 주입
+    @Lazy
+    @Autowired
+    private ExhibitionSchedulerService self;
+
     private static final int CHUNK_SIZE = 100;
     private static final ZoneId SEOUL_ZONE = ZoneId.of("Asia/Seoul");
 
     @Value("${inventory.kafka.topic.status-changed:product.status-changed}")
     private String topicStatusChanged;
 
-    @Transactional
+    // 외부 진입점의 @Transactional을 제거하여 영속성 컨텍스트 비대화를 막음
     @Scheduled(cron = "0 0 * * * *", zone = "Asia/Seoul") // 매 정시(0분 0초)마다 실행
     public void updateExhibitionStatus() {
         log.info("정시 전시 상태 변경 스케줄러 시작...");
@@ -45,27 +53,47 @@ public class ExhibitionSchedulerService {
     }
 
     private void processOpeningProducts(LocalDateTime now) {
-        Slice<Product> slice;
-        do {
-            // 변경된 데이터는 다음 조회(status='HIDDEN')에서 제외되므로 페이지넘버를 0으로 고정함
-            slice = productRepository.findProductsToOpen(now, PageRequest.of(0, CHUNK_SIZE));
-            for (Product product : slice.getContent()) {
-                product.changeStatus(ProductStatus.ACTIVE);
-                publishStatusChangeEventAfterCommit(product); // 트랜잭션 커밋 후 발행
+        while (true) {
+            // 프록시 객체를 통해 호출하여 매 루프(Chunk)마다 독립된 트랜잭션을 연다
+            int processed = self.processOpeningChunk(now);
+            if (processed == 0) {
+                break;
             }
-        } while (slice.hasNext());
+        }
     }
 
     private void processClosingProducts(LocalDateTime now) {
-        Slice<Product> slice;
-        do {
-            // 변경된 데이터는 다음 조회(status='ACTIVE')에서 제외되므로 페이지넘버를 0으로 고정함
-            slice = productRepository.findProductsToClose(now, PageRequest.of(0, CHUNK_SIZE));
-            for (Product product : slice.getContent()) {
-                product.changeStatus(ProductStatus.HIDDEN);
-                publishStatusChangeEventAfterCommit(product); // 트랜잭션 커밋 후 발행
+        while (true) {
+            int processed = self.processClosingChunk(now);
+            if (processed == 0) {
+                break;
             }
-        } while (slice.hasNext());
+        }
+    }
+
+    // REQUIRES_NEW: 청크가 끝날 때마다 DB 트랜잭션을 커밋하고 L1 캐시를 비워 OOM을 방지함
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public int processOpeningChunk(LocalDateTime now) {
+        Slice<Product> slice = productRepository.findProductsToOpen(now, PageRequest.of(0, CHUNK_SIZE));
+
+        for (Product product : slice.getContent()) {
+            product.changeStatus(ProductStatus.ACTIVE);
+            publishStatusChangeEventAfterCommit(product);
+        }
+
+        return slice.getNumberOfElements();
+    }
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public int processClosingChunk(LocalDateTime now) {
+        Slice<Product> slice = productRepository.findProductsToClose(now, PageRequest.of(0, CHUNK_SIZE));
+
+        for (Product product : slice.getContent()) {
+            product.changeStatus(ProductStatus.HIDDEN);
+            publishStatusChangeEventAfterCommit(product);
+        }
+
+        return slice.getNumberOfElements();
     }
 
     // DB 커밋 성공 시에만 카프카로 이벤트 발행 보장

--- a/src/main/java/com/michelet/inventory/application/ExhibitionSchedulerService.java
+++ b/src/main/java/com/michelet/inventory/application/ExhibitionSchedulerService.java
@@ -1,0 +1,78 @@
+package com.michelet.inventory.application;
+
+import com.michelet.inventory.application.dto.ProductStatusChangedEvent;
+import com.michelet.inventory.domain.model.Product;
+import com.michelet.inventory.domain.model.ProductStatus;
+import com.michelet.inventory.domain.repository.ProductRepository;
+import java.time.LocalDateTime;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Slice;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ExhibitionSchedulerService {
+
+    private final ProductRepository productRepository;
+    private final KafkaTemplate<String, Object> kafkaTemplate;
+
+    private static final int CHUNK_SIZE = 100;
+
+    @Value("${inventory.kafka.topic.status-changed:product.status-changed}")
+    private String topicStatusChanged;
+
+    @Transactional
+    @Scheduled(cron = "0 0 * * * *", zone = "Asia/Seoul") // 매 정시(0분 0초)마다 실행
+    public void updateExhibitionStatus() {
+        log.info("정시 전시 상태 변경 스케줄러 시작...");
+        LocalDateTime now = LocalDateTime.now();
+
+        processOpeningProducts(now);
+        processClosingProducts(now);
+
+        log.info("정시 전시 상태 변경 스케줄러 완료.");
+    }
+
+    private void processOpeningProducts(LocalDateTime now) {
+        int page = 0;
+        Slice<Product> slice;
+        do {
+            slice = productRepository.findProductsToOpen(now, PageRequest.of(page, CHUNK_SIZE));
+            for (Product product : slice.getContent()) {
+                product.changeStatus(ProductStatus.ACTIVE);
+                publishStatusChangeEvent(product);
+            }
+            page++;
+        } while (slice.hasNext());
+    }
+
+    private void processClosingProducts(LocalDateTime now) {
+        int page = 0;
+        Slice<Product> slice;
+        do {
+            slice = productRepository.findProductsToClose(now, PageRequest.of(page, CHUNK_SIZE));
+            for (Product product : slice.getContent()) {
+                product.changeStatus(ProductStatus.HIDDEN);
+                publishStatusChangeEvent(product);
+            }
+            page++;
+        } while (slice.hasNext());
+    }
+
+    private void publishStatusChangeEvent(Product product) {
+        ProductStatusChangedEvent event = new ProductStatusChangedEvent(product.getId(), product.getStatus().name());
+        kafkaTemplate.send(topicStatusChanged, product.getId().toString(), event)
+            .whenComplete((result, ex) -> {
+                if (ex != null) {
+                    log.error("상품 상태 변경 카프카 이벤트 발행 실패: productId={}", product.getId(), ex);
+                }
+            });
+    }
+}

--- a/src/main/java/com/michelet/inventory/application/ProductCommandService.java
+++ b/src/main/java/com/michelet/inventory/application/ProductCommandService.java
@@ -11,6 +11,7 @@ import com.michelet.inventory.domain.repository.ProductExhibitionRepository;
 import com.michelet.inventory.domain.repository.ProductOptionRepository;
 import com.michelet.inventory.domain.repository.ProductRepository;
 import com.michelet.inventory.domain.repository.StockRepository;
+import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -83,11 +84,17 @@ public class ProductCommandService {
             CreateProductCommand.OptionCommand reqOption = requestOptions.get(i);
             ProductOption dbOption = savedOptions.get(i);
 
+            // Positional Arguments 실수 방지를 위해 명시적 지역변수 선언
+            BigDecimal addPrice = dbOption.getAddPrice();
+            Integer totalQuantity = reqOption.totalQuantity();
+            Integer dailyLimit = reqOption.dailyLimit();
+            Integer currentDailyStock = reqOption.dailyLimit(); // 초기 생성 시에는 일일 한도와 같음
+
             // DB 저장을 위한 Stock 객체 생성
             stocks.add(Stock.create(
                 dbOption.getId(),
-                reqOption.totalQuantity(),
-                reqOption.dailyLimit(),
+                totalQuantity,
+                dailyLimit,
                 reqOption.maxLimit()
             ));
 
@@ -95,10 +102,10 @@ public class ProductCommandService {
             optionEventDtos.add(new ProductCreatedEvent.OptionEventDto(
                 dbOption.getId(),
                 dbOption.getName(),
-                dbOption.getAddPrice(),
-                reqOption.totalQuantity(),
-                reqOption.dailyLimit(), // currentDailyStock은 dailyLimit으로 초기화
-                reqOption.dailyLimit()
+                addPrice,
+                totalQuantity,
+                currentDailyStock,
+                dailyLimit
             ));
         }
         stockRepository.saveAll(stocks);

--- a/src/main/java/com/michelet/inventory/application/ProductCommandService.java
+++ b/src/main/java/com/michelet/inventory/application/ProductCommandService.java
@@ -97,7 +97,8 @@ public class ProductCommandService {
                 dbOption.getName(),
                 dbOption.getAddPrice(),
                 reqOption.totalQuantity(),
-                reqOption.dailyLimit() // currentDailyStock은 dailyLimit으로 초기화
+                reqOption.dailyLimit(), // currentDailyStock은 dailyLimit으로 초기화
+                reqOption.dailyLimit()
             ));
         }
         stockRepository.saveAll(stocks);

--- a/src/main/java/com/michelet/inventory/application/StockSchedulerService.java
+++ b/src/main/java/com/michelet/inventory/application/StockSchedulerService.java
@@ -1,34 +1,50 @@
-//package com.michelet.inventory.application;
-//
-//import com.michelet.inventory.domain.repository.StockRepository;
-//import lombok.RequiredArgsConstructor;
-//import lombok.extern.slf4j.Slf4j;
-//import org.springframework.scheduling.annotation.Scheduled;
-//import org.springframework.stereotype.Service;
-//import org.springframework.transaction.annotation.Transactional;
-//
-//@Slf4j
-//@Service
-//@RequiredArgsConstructor
-//TODO 일일재고복구
-//public class StockSchedulerService {
-//
-//    private final StockRepository stockRepository;
-//
-//    // "초 분 시 일 월 요일" 순서임
-//    // 매일 자정(0시 0분 0초)에 실행하려면: @Scheduled(cron = "0 0 0 * * *")
-//    // (테스트용) 1분마다 실행하려면: @Scheduled(cron = "0 * * * * *")
-//
-//    @Transactional
-//    @Scheduled(cron = "0 0 0 * * *", zone = "Asia/Seoul") // 한국 시각 기준 매일 자정
-//    public void resetDailyStocks() {
-//        log.info("일일 재고 초기화 스케줄러 시작...");
-//
-//        int updatedCount = stockRepository.resetDailyStock();
-//
-//        log.info("일일 재고 초기화 완료! 업데이트된 상품 수: {}", updatedCount);
-//
-//        // TODO: 카탈로그 서비스(MongoDB)에도 이 초기화 사실을 알려야해서
-//        //  여기서 "전체 재고 초기화 이벤트"를 Kafka로 던져주는 로직을 나중에 추가해야함
-//    }
-//}
+package com.michelet.inventory.application;
+
+import com.michelet.inventory.application.dto.DailyStockResetEvent;
+import com.michelet.inventory.domain.repository.StockRepository;
+import java.time.LocalDate;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class StockSchedulerService {
+
+    private final StockRepository stockRepository;
+    private final KafkaTemplate<String, Object> kafkaTemplate;
+
+    @Value("${inventory.kafka.topic.daily-reset:stock.daily-reset}")
+    private String topicDailyReset;
+
+    // "초 분 시 일 월 요일" 순서임
+    // 매일 자정(0시 0분 0초)에 실행하려면: @Scheduled(cron = "0 0 0 * * *")
+    // (테스트용) 1분마다 실행하려면: @Scheduled(cron = "0 * * * * *")
+
+    @Transactional
+    @Scheduled(cron = "0 0 0 * * *", zone = "Asia/Seoul") // 한국 시각 기준 매일 자정
+    public void resetDailyStocks() {
+        log.info("일일 재고 초기화 스케줄러 시작...");
+
+        int updatedCount = stockRepository.resetDailyStock();
+
+        log.info("일일 재고 초기화 완료! 업데이트된 상품 옵션 수: {}", updatedCount);
+
+        // 카탈로그 서비스(MongoDB)에도 이 초기화 사실을 알려야 함
+        // 여기서 전체 재고 초기화 이벤트를 Kafka로 던져줌
+        if (updatedCount > 0) {
+            DailyStockResetEvent event = new DailyStockResetEvent(LocalDate.now(), updatedCount);
+            kafkaTemplate.send(topicDailyReset, "ALL_STOCKS", event)
+                .whenComplete((result, ex) -> {
+                    if (ex != null) {
+                        log.error("일일 재고 초기화 카프카 이벤트 발행 실패", ex);
+                    }
+                });
+        }
+    }
+}

--- a/src/main/java/com/michelet/inventory/application/StockSchedulerService.java
+++ b/src/main/java/com/michelet/inventory/application/StockSchedulerService.java
@@ -3,6 +3,7 @@ package com.michelet.inventory.application;
 import com.michelet.inventory.application.dto.DailyStockResetEvent;
 import com.michelet.inventory.domain.repository.StockRepository;
 import java.time.LocalDate;
+import java.time.ZoneId;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -10,6 +11,8 @@ import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
 
 @Slf4j
 @Service
@@ -35,16 +38,31 @@ public class StockSchedulerService {
 
         log.info("일일 재고 초기화 완료! 업데이트된 상품 옵션 수: {}", updatedCount);
 
-        // 카탈로그 서비스(MongoDB)에도 이 초기화 사실을 알려야 함
-        // 여기서 전체 재고 초기화 이벤트를 Kafka로 던져줌
+        // 카탈로그 서비스(MongoDB)에도 이 초기화 사실을 알려야해서 - 여기서 전체 재고 초기화 이벤트를 Kafka로 던져줌
         if (updatedCount > 0) {
-            DailyStockResetEvent event = new DailyStockResetEvent(LocalDate.now(), updatedCount);
-            kafkaTemplate.send(topicDailyReset, "ALL_STOCKS", event)
-                .whenComplete((result, ex) -> {
-                    if (ex != null) {
-                        log.error("일일 재고 초기화 카프카 이벤트 발행 실패", ex);
+            LocalDate todayInSeoul = LocalDate.now(ZoneId.of("Asia/Seoul"));
+            DailyStockResetEvent event = new DailyStockResetEvent(todayInSeoul, updatedCount);
+
+            // DB 트랜잭션이 정상적으로 커밋된 이후에만 발행되도록!
+            if (TransactionSynchronizationManager.isSynchronizationActive()) {
+                TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+                    @Override
+                    public void afterCommit() {
+                        sendKafkaEvent(event);
                     }
                 });
+            } else {
+                sendKafkaEvent(event);
+            }
         }
+    }
+
+    private void sendKafkaEvent(DailyStockResetEvent event) {
+        kafkaTemplate.send(topicDailyReset, "ALL_STOCKS", event)
+            .whenComplete((result, ex) -> {
+                if (ex != null) {
+                    log.error("일일 재고 초기화 카프카 이벤트 발행 실패", ex);
+                }
+            });
     }
 }

--- a/src/main/java/com/michelet/inventory/application/dto/DailyStockResetEvent.java
+++ b/src/main/java/com/michelet/inventory/application/dto/DailyStockResetEvent.java
@@ -1,0 +1,9 @@
+package com.michelet.inventory.application.dto;
+
+import java.time.LocalDate;
+
+public record DailyStockResetEvent(
+    LocalDate resetDate,
+    int updatedOptionCount
+) {
+}

--- a/src/main/java/com/michelet/inventory/application/dto/ProductCreatedEvent.java
+++ b/src/main/java/com/michelet/inventory/application/dto/ProductCreatedEvent.java
@@ -37,7 +37,8 @@ public record ProductCreatedEvent(
         String name,
         BigDecimal addPrice,
         Integer totalQuantity,
-        Integer currentDailyStock
+        Integer currentDailyStock,
+        Integer dailyLimit
     ) {
         public OptionEventDto {
             Objects.requireNonNull(optionId, "optionId는 필수입니다.");
@@ -45,8 +46,9 @@ public record ProductCreatedEvent(
             Objects.requireNonNull(addPrice, "addPrice는 필수입니다.");
             Objects.requireNonNull(totalQuantity, "totalQuantity는 필수입니다.");
             Objects.requireNonNull(currentDailyStock, "currentDailyStock는 필수입니다.");
+            Objects.requireNonNull(dailyLimit, "dailyLimit는 필수입니다.");
 
-            if (totalQuantity < 0 || currentDailyStock < 0) {
+            if (totalQuantity < 0 || currentDailyStock < 0 || dailyLimit < 0) {
                 throw new IllegalArgumentException("재고 수량은 0 이상이어야 합니다.");
             }
         }

--- a/src/main/java/com/michelet/inventory/application/dto/ProductStatusChangedEvent.java
+++ b/src/main/java/com/michelet/inventory/application/dto/ProductStatusChangedEvent.java
@@ -1,0 +1,9 @@
+package com.michelet.inventory.application.dto;
+
+import java.util.UUID;
+
+public record ProductStatusChangedEvent(
+    UUID productId,
+    String newStatus
+) {
+}

--- a/src/main/java/com/michelet/inventory/domain/model/Product.java
+++ b/src/main/java/com/michelet/inventory/domain/model/Product.java
@@ -85,6 +85,7 @@ public class Product extends BaseEntity {
 
     // 전시 상태 변경
     public void changeStatus(ProductStatus newStatus) {
+        Objects.requireNonNull(newStatus, "새로운 상태(newStatus)는 null일 수 없습니다.");
         this.status = newStatus;
     }
 }

--- a/src/main/java/com/michelet/inventory/domain/model/Product.java
+++ b/src/main/java/com/michelet/inventory/domain/model/Product.java
@@ -82,4 +82,9 @@ public class Product extends BaseEntity {
     public Map<String, Object> getAttributes() {
         return Collections.unmodifiableMap(attributes);
     }
+
+    // 전시 상태 변경
+    public void changeStatus(ProductStatus newStatus) {
+        this.status = newStatus;
+    }
 }

--- a/src/main/java/com/michelet/inventory/domain/repository/ProductRepository.java
+++ b/src/main/java/com/michelet/inventory/domain/repository/ProductRepository.java
@@ -1,11 +1,18 @@
 package com.michelet.inventory.domain.repository;
 
 import com.michelet.inventory.domain.model.Product;
+import java.time.LocalDateTime;
 import java.util.Optional;
 import java.util.UUID;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 
 public interface ProductRepository {
     Product save(Product product);
 
     Optional<Product> findById(UUID id);
+
+    Slice<Product> findProductsToOpen(LocalDateTime now, Pageable pageable);
+
+    Slice<Product> findProductsToClose(LocalDateTime now, Pageable pageable);
 }

--- a/src/main/java/com/michelet/inventory/domain/repository/StockRepository.java
+++ b/src/main/java/com/michelet/inventory/domain/repository/StockRepository.java
@@ -14,7 +14,6 @@ public interface StockRepository {
 
     void deleteAll();
 
-    //TODO 일일재고복구
-//    // 도메인 인터페이스에 스케줄러가 호출할 메서드
-//    int resetDailyStock();
+    // 일일재고복구 - 도메인 인터페이스에 스케줄러가 호출할 메서드
+    int resetDailyStock();
 }

--- a/src/main/java/com/michelet/inventory/infrastructure/repository/JpaProductRepository.java
+++ b/src/main/java/com/michelet/inventory/infrastructure/repository/JpaProductRepository.java
@@ -1,8 +1,23 @@
 package com.michelet.inventory.infrastructure.repository;
 
 import com.michelet.inventory.domain.model.Product;
+import java.time.LocalDateTime;
 import java.util.UUID;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface JpaProductRepository extends JpaRepository<Product, UUID> {
+
+    // 전시 시작 시간이 지났는데 아직 숨김(HIDDEN)인 상품 조회
+    @Query("SELECT p FROM Product p JOIN ProductExhibition e ON p.id = e.productId " +
+        "WHERE p.status = 'HIDDEN' AND e.startAt <= :now AND (e.endAt IS NULL OR e.endAt > :now)")
+    Slice<Product> findProductsToOpen(@Param("now") LocalDateTime now, Pageable pageable);
+
+    // 전시 종료 시간이 지났는데 아직 판매 중(ACTIVE)인 상품 조회
+    @Query("SELECT p FROM Product p JOIN ProductExhibition e ON p.id = e.productId " +
+        "WHERE p.status = 'ACTIVE' AND e.endAt <= :now")
+    Slice<Product> findProductsToClose(@Param("now") LocalDateTime now, Pageable pageable);
 }

--- a/src/main/java/com/michelet/inventory/infrastructure/repository/JpaProductRepository.java
+++ b/src/main/java/com/michelet/inventory/infrastructure/repository/JpaProductRepository.java
@@ -13,11 +13,13 @@ public interface JpaProductRepository extends JpaRepository<Product, UUID> {
 
     // 전시 시작 시간이 지났는데 아직 숨김(HIDDEN)인 상품 조회
     @Query("SELECT p FROM Product p JOIN ProductExhibition e ON p.id = e.productId " +
-        "WHERE p.status = 'HIDDEN' AND e.startAt <= :now AND (e.endAt IS NULL OR e.endAt > :now)")
+        "WHERE p.status = 'HIDDEN' AND e.startAt <= :now AND (e.endAt IS NULL OR e.endAt > :now) " +
+        "ORDER BY p.id ASC")
     Slice<Product> findProductsToOpen(@Param("now") LocalDateTime now, Pageable pageable);
 
     // 전시 종료 시간이 지났는데 아직 판매 중(ACTIVE)인 상품 조회
     @Query("SELECT p FROM Product p JOIN ProductExhibition e ON p.id = e.productId " +
-        "WHERE p.status = 'ACTIVE' AND e.endAt <= :now")
+        "WHERE p.status = 'ACTIVE' AND e.endAt <= :now " +
+        "ORDER BY p.id ASC")
     Slice<Product> findProductsToClose(@Param("now") LocalDateTime now, Pageable pageable);
 }

--- a/src/main/java/com/michelet/inventory/infrastructure/repository/JpaStockRepository.java
+++ b/src/main/java/com/michelet/inventory/infrastructure/repository/JpaStockRepository.java
@@ -10,6 +10,6 @@ public interface JpaStockRepository extends JpaRepository<Stock, UUID> {
 
     // 일일재고복구 - 벌크 업데이트 쿼리
     @Modifying(clearAutomatically = true)
-    @Query("UPDATE p_stocks s SET s.currentDailyStock = s.dailyLimit, s.version = s.version + 1 WHERE s.currentDailyStock < s.dailyLimit")
+    @Query("UPDATE p_stocks s SET s.currentDailyStock = s.dailyLimit, s.version = s.version + 1 WHERE s.currentDailyStock <> s.dailyLimit")
     int resetDailyStock();
 }

--- a/src/main/java/com/michelet/inventory/infrastructure/repository/JpaStockRepository.java
+++ b/src/main/java/com/michelet/inventory/infrastructure/repository/JpaStockRepository.java
@@ -3,11 +3,13 @@ package com.michelet.inventory.infrastructure.repository;
 import com.michelet.inventory.domain.model.Stock;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 
 public interface JpaStockRepository extends JpaRepository<Stock, UUID> {
 
-    //TODO 일일재고복구 - 벌크 업데이트 쿼리
-//    @Modifying(clearAutomatically = true)
-//    @Query("UPDATE p_stocks s SET s.currentDailyStock = s.dailyLimit, s.version = s.version + 1 WHERE s.currentDailyStock < s.dailyLimit")
-//    int resetDailyStock();
+    // 일일재고복구 - 벌크 업데이트 쿼리
+    @Modifying(clearAutomatically = true)
+    @Query("UPDATE p_stocks s SET s.currentDailyStock = s.dailyLimit, s.version = s.version + 1 WHERE s.currentDailyStock < s.dailyLimit")
+    int resetDailyStock();
 }

--- a/src/main/java/com/michelet/inventory/infrastructure/repository/ProductRepositoryImpl.java
+++ b/src/main/java/com/michelet/inventory/infrastructure/repository/ProductRepositoryImpl.java
@@ -2,9 +2,12 @@ package com.michelet.inventory.infrastructure.repository;
 
 import com.michelet.inventory.domain.model.Product;
 import com.michelet.inventory.domain.repository.ProductRepository;
+import java.time.LocalDateTime;
 import java.util.Optional;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -20,5 +23,15 @@ public class ProductRepositoryImpl implements ProductRepository {
     @Override
     public Optional<Product> findById(UUID id) {
         return jpaRepository.findById(id);
+    }
+
+    @Override
+    public Slice<Product> findProductsToOpen(LocalDateTime now, Pageable pageable) {
+        return jpaRepository.findProductsToOpen(now, pageable);
+    }
+
+    @Override
+    public Slice<Product> findProductsToClose(LocalDateTime now, Pageable pageable) {
+        return jpaRepository.findProductsToClose(now, pageable);
     }
 }

--- a/src/main/java/com/michelet/inventory/infrastructure/repository/StockRepositoryImpl.java
+++ b/src/main/java/com/michelet/inventory/infrastructure/repository/StockRepositoryImpl.java
@@ -33,9 +33,9 @@ public class StockRepositoryImpl implements StockRepository {
         jpaStockRepository.deleteAll();
     }
 
-    //TODO 일일재고복구
-//    @Override
-//    public int resetDailyStock() {
-//        return jpaStockRepository.resetDailyStock();
-//    }
+    // 일일재고복구
+    @Override
+    public int resetDailyStock() {
+        return jpaStockRepository.resetDailyStock();
+    }
 }

--- a/src/main/java/com/michelet/inventory/presentation/SchedulerTriggerController.java
+++ b/src/main/java/com/michelet/inventory/presentation/SchedulerTriggerController.java
@@ -3,9 +3,12 @@ package com.michelet.inventory.presentation;
 import com.michelet.inventory.application.ExhibitionSchedulerService;
 import com.michelet.inventory.application.StockSchedulerService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.server.ResponseStatusException;
 
 @RestController
 @RequestMapping("/internal/scheduler")
@@ -17,15 +20,25 @@ public class SchedulerTriggerController {
 
     // 일일 재고 강제 리셋 버튼 - 테스트용!
     @PostMapping("/trigger-stock")
-    public String triggerStock() {
+    public String triggerStock(
+        @RequestHeader(value = "X-User-Role", required = true) String userRole
+    ) {
+        if (!"SYSTEM".equals(userRole)) {
+            throw new ResponseStatusException(HttpStatus.FORBIDDEN, "시스템 내부 통신만 접근 가능합니다.");
+        }
         stockSchedulerService.resetDailyStocks();
-        return "OK - Stock Reset Triggered";
+        return "재고 리셋 트리거 작동";
     }
 
     // 정시 전시 상태 강제 갱신 버튼 - 테스트용!
     @PostMapping("/trigger-exhibition")
-    public String triggerExhibition() {
+    public String triggerExhibition(
+        @RequestHeader(value = "X-User-Role", required = true) String userRole
+    ) {
+        if (!"SYSTEM".equals(userRole)) {
+            throw new ResponseStatusException(HttpStatus.FORBIDDEN, "시스템 내부 통신만 접근 가능합니다.");
+        }
         exhibitionSchedulerService.updateExhibitionStatus();
-        return "OK - Exhibition Status Triggered";
+        return "전시 상태 갱신 트리거 작동";
     }
 }

--- a/src/main/java/com/michelet/inventory/presentation/SchedulerTriggerController.java
+++ b/src/main/java/com/michelet/inventory/presentation/SchedulerTriggerController.java
@@ -1,0 +1,31 @@
+package com.michelet.inventory.presentation;
+
+import com.michelet.inventory.application.ExhibitionSchedulerService;
+import com.michelet.inventory.application.StockSchedulerService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/internal/scheduler")
+@RequiredArgsConstructor
+public class SchedulerTriggerController {
+
+    private final StockSchedulerService stockSchedulerService;
+    private final ExhibitionSchedulerService exhibitionSchedulerService;
+
+    // 일일 재고 강제 리셋 버튼 - 테스트용!
+    @PostMapping("/trigger-stock")
+    public String triggerStock() {
+        stockSchedulerService.resetDailyStocks();
+        return "OK - Stock Reset Triggered";
+    }
+
+    // 정시 전시 상태 강제 갱신 버튼 - 테스트용!
+    @PostMapping("/trigger-exhibition")
+    public String triggerExhibition() {
+        exhibitionSchedulerService.updateExhibitionStatus();
+        return "OK - Exhibition Status Triggered";
+    }
+}

--- a/src/main/resources/application-docker.yml
+++ b/src/main/resources/application-docker.yml
@@ -12,11 +12,7 @@ spring:
             host: redis
             port: 6379
     kafka:
-        bootstrap-servers: kafka:9092
-        producer:
-            key-serializer: org.apache.kafka.common.serialization.StringSerializer
-            value-serializer: org.springframework.kafka.support.serializer.JsonSerializer
-
+        bootstrap-servers: kafka:9092 # 도커는 컨테이너 이름(kafka)
 eureka:
     client:
         service-url:

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -23,5 +23,3 @@ eureka:
         service-url:
             defaultZone: http://localhost:8761/eureka/
 
-jwt:
-    secret: ${JWT_SECRET}

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -14,12 +14,7 @@ spring:
             port: 6379
     kafka:
         bootstrap-servers: localhost:9092
-        producer:
-            key-serializer: org.apache.kafka.common.serialization.StringSerializer
-            value-serializer: org.springframework.kafka.support.serializer.JsonSerializer
-
 eureka:
     client:
         service-url:
             defaultZone: http://localhost:8761/eureka/
-

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -22,3 +22,5 @@ inventory:
             product-created: "product.created"
             reserved: "stock.reserved"
             restored: "stock.restored"
+            status-changed: "product.status-changed"
+            daily-reset: "stock.daily-reset"

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -24,3 +24,9 @@ inventory:
             restored: "stock.restored"
             status-changed: "product.status-changed"
             daily-reset: "stock.daily-reset"
+
+internal:
+    auth:
+        secret: ${INTERNAL_AUTH_SECRET}
+jwt:
+    secret: ${JWT_SECRET}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -11,6 +11,17 @@ spring:
                 default_schema: inventory_service
                 hbm2ddl.create_namespaces: true
 
+    kafka:
+        producer:
+            key-serializer: org.apache.kafka.common.serialization.StringSerializer
+            value-serializer: org.springframework.kafka.support.serializer.JsonSerializer
+            acks: all                                 # 모든 ISR 복제본으로부터 ack 수신 후 성공 처리
+            retries: 3                                # 일시적 오류 시 최대 3회 재시도
+            properties:
+                enable.idempotence: true              # 재시도로 인한 중복 메시지 방지 (exactly-once)
+                max.in.flight.requests.per.connection: 5
+                retry.backoff.ms: 1000
+
 server:
     port: 19900
 

--- a/src/test/java/com/michelet/inventory/application/StockSchedulerServiceTest.java
+++ b/src/test/java/com/michelet/inventory/application/StockSchedulerServiceTest.java
@@ -1,0 +1,42 @@
+package com.michelet.inventory.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.michelet.inventory.domain.model.Stock;
+import com.michelet.inventory.infrastructure.repository.JpaStockRepository;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+@SpringBootTest
+@ActiveProfiles("test")
+@Transactional
+class StockSchedulerServiceTest {
+
+    @Autowired
+    private StockSchedulerService stockSchedulerService;
+
+    @Autowired
+    private JpaStockRepository jpaStockRepository;
+
+    @Test
+    @DisplayName("일일 재고 초기화 스케줄러 동작 테스트")
+    void resetDailyStocks() {
+        // given: dailyLimit은 50인데 현재 재고가 10으로 깎여있는 데이터 세팅
+        UUID optionId = UUID.randomUUID();
+        Stock stock = Stock.create(optionId, 100, 50, 50);
+        stock.reserve(40); // 40개 차감 -> currentDailyStock이 10이 됨
+        jpaStockRepository.saveAndFlush(stock);
+
+        // when: 자정이 되었다고 가정하고 스케줄러 메서드를 강제로 직접 호출!
+        stockSchedulerService.resetDailyStocks();
+
+        // then: DB에서 다시 조회했을 때 일일 재고가 50으로 꽉 차있어야 함
+        Stock resetStock = jpaStockRepository.findById(optionId).orElseThrow();
+        assertThat(resetStock.getCurrentDailyStock()).isEqualTo(50);
+    }
+}

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -35,6 +35,9 @@ spring:
             key-serializer: org.apache.kafka.common.serialization.StringSerializer
             value-serializer: org.springframework.kafka.support.serializer.JsonSerializer
 
+internal:
+    auth:
+        secret: ${INTERNAL_AUTH_SECRET:michelet-internal-auth-secret-key-a8K2mQ9xLp4Vt7Rz1Nc}
 jwt:
     secret: ${JWT_SECRET:michelet-secret-key-for-authentication}
 

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -46,4 +46,6 @@ inventory:
             product-created: "product.created"
             reserved: "stock.reserved"
             restored: "stock.restored"
+            status-changed: "product.status-changed"
+            daily-reset: "stock.daily-reset"
 


### PR DESCRIPTION
## 📝 작업 내용
> 이번 PR에서 작업한 내용을 설명해주세요.

인벤토리 서비스의 비즈니스 정책에 따라 전시 기간이 만료된 상품의 상태를 자동으로 변경하고, 매일 자정 일일 판매 한도(dailyLimit)를 초기화하는 스케줄러 기능을 구현

## 🚀 주요 변경 사항
> 완료한 이슈 번호 \
> Close #13   \
> 관련된 이슈 번호 (닫고 싶지 않은 경우) \
> Related to # 

## ✅ 자체 체크리스트 (필수)
- [x] `./gradlew build` 실행 결과 정상 (인증샷 첨부)
- [x] IntelliJ HTTP Client 테스트 완료 (인증샷 첨부)
- [x] 팀 내 컨벤션 준수 및 불필요한 로그, import 제거
- [x] 중요한 변경 사항이 팀에 공유되었는지

## 📸 테스트 인증샷
> 빌드 결과 및 IntelliJ HTTP Client 실행 화면을 여기에 첨부해 주세요.
<img width="1022" height="212" alt="스크린샷 2026-05-04 오전 4 29 15" src="https://github.com/user-attachments/assets/360cf3fe-683c-42bb-bcbf-7794835e778b" />
<img width="1035" height="221" alt="스크린샷 2026-05-04 오전 4 29 20" src="https://github.com/user-attachments/assets/a804b8f9-156a-43a9-acff-e2d948a671cb" />


## 💬 리뷰어 전달사항 (선택)
> 특별히 봐주었으면 하는 부분이나 논의가 필요한 점을 적어주세요.

* 테스트 하실 거라면 catalog와 함께 하셔야 합니다

<br>

---
## 📎 참고 자료

> 관련 문서, 레퍼런스 링크 등이 있다면 여기에 첨부해주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 전시 상태를 정해진 시간에 자동으로 갱신하는 스케줄러 추가(개시/종료 처리, 상태 변경 이벤트 발행)
  * 매일 일일 재고를 자동으로 리셋하는 스케줄러 추가(변경이 있을 때만 이벤트 발행)
  * 내부에서 스케줄러를 수동으로 호출하는 트리거 API 추가(권한 검증 포함)

* **테스트**
  * 일일 재고 리셋 동작을 검증하는 통합 테스트 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->