### PR TITLE
bug/15 - 매일 재고 복구 시의 일일재고값 > 총 재고값 되던 오류 수정

### DIFF
--- a/api-test/inventory.http
+++ b/api-test/inventory.http
@@ -190,3 +190,91 @@ X-User-Role: SYSTEM
         client.assert(response.status === 200, "재고 리셋 스케줄러 호출에 실패했습니다.");
     });
 %}
+
+### 7. [Test] 재고 소진 테스트용 상품 등록 (총 재고 25, 일일 20)
+POST http://{{host}}:{{gatewayPort}}/api/v1/products
+Content-Type: application/json
+Authorization: Bearer {{auth_token}}
+
+{
+    "restaurantId": "550e8400-e29b-41d4-a716-446655440000",
+    "name": "품절 임박 리셋 테스트 코스",
+    "category": "MEALKIT",
+    "basePrice": 50000,
+    "attributes": {},
+    "exhibition": {
+        "startAt": "2024-01-01T00:00:00",
+        "endAt": "2099-12-31T23:59:59"
+    },
+    "options": [
+        {
+            "name": "한정판 옵션",
+            "addPrice": 0,
+            "totalQuantity": 25,
+            "dailyLimit": 20,
+            "maxLimit": 20
+        }
+    ]
+}
+
+> {%
+    client.test("테스트용 상품 등록 성공", function () {
+        client.assert(response.status === 200, "상품 등록 실패");
+        var data = response.body.data;
+        client.global.set("depletion_product_id", data.productId);
+        client.global.set("depletion_option_id", data.options[0].optionId);
+        client.log("[초기 상태] 총 재고: 25, 일일 한도: 20");
+    });
+%}
+
+### 8. [Test] 20개 대량 구매 (총 재고 5개 남음)
+POST http://{{host}}:{{inventoryPort}}/internal/stocks/reserve
+Content-Type: application/json
+X-User-Role: SYSTEM
+
+{
+  "optionId": "{{depletion_option_id}}",
+  "quantity": 20
+}
+
+> {%
+    client.test("대량 재고 선점 성공", function () {
+        client.assert(response.status === 200, "재고 선점 실패");
+        client.log("[판매 완료] 20개 구매됨 -> 이론상 총 재고 5, 일일 재고 0 이어야 함");
+    });
+%}
+
+### 9. [Test] 자정이 되었다고 가정하고 스케줄러 트리거 실행
+POST http://{{host}}:{{inventoryPort}}/internal/scheduler/trigger-stock
+Content-Type: application/json
+X-User-Role: SYSTEM
+
+> {%
+    client.test("자정 리셋 스케줄러 실행", function () {
+        client.assert(response.status === 200, "스케줄러 호출 실패");
+        client.log("자정 스케줄러 가동! (LEAST 쿼리 작동)");
+    });
+%}
+
+### 10. [Test] 카탈로그 최종 동기화 검증 (CQRS Ping-Pong)
+# 스케줄러가 일일 재고를 20(한도)이 아닌 5(총재고)로 맞춰서 카프카로 잘 쐈는지 카탈로그를 조회하여 검증
+GET http://{{host}}:{{gatewayPort}}/api/v1/products/{{depletion_product_id}}
+Accept: application/json
+Authorization: Bearer {{auth_token}}
+
+> {%
+    client.test("한계 재고 리셋 로직(Math.min) 카탈로그 동기화 완벽 검증", function () {
+        client.assert(response.status === 200, "카탈로그 조회 실패");
+        client.assert(response.body && response.body.data, "응답 데이터 누락");
+
+        var option = response.body.data.options[0];
+
+        client.assert(option.totalQuantity === 5, "예상 총 재고: 5, 실제: " + option.totalQuantity);
+        client.assert(option.currentDailyStock === 5, "예상 일일 재고(Math.min 적용): 5, 실제: " + option.currentDailyStock);
+
+        client.log("=======================================");
+        client.log("성공! 총 재고(5)가 일일 한도(20)를 초과하여 충전되지 않았습니다.");
+        client.log("최종 상태 - 총 재고: " + option.totalQuantity + " / 오늘 팔 수 있는 수량: " + option.currentDailyStock);
+        client.log("=======================================");
+    });
+%}

--- a/api-test/inventory.http
+++ b/api-test/inventory.http
@@ -256,7 +256,7 @@ X-User-Role: SYSTEM
     });
 %}
 
-### 10. [Test] 카탈로그 최종 동기화 검증 (CQRS Ping-Pong)
+### 10. [Test] 카탈로그 최종 동기화 검증
 # 스케줄러가 일일 재고를 20(한도)이 아닌 5(총재고)로 맞춰서 카프카로 잘 쐈는지 카탈로그를 조회하여 검증
 GET http://{{host}}:{{gatewayPort}}/api/v1/products/{{depletion_product_id}}
 Accept: application/json

--- a/src/main/java/com/michelet/inventory/application/ProductCommandService.java
+++ b/src/main/java/com/michelet/inventory/application/ProductCommandService.java
@@ -88,7 +88,7 @@ public class ProductCommandService {
             BigDecimal addPrice = dbOption.getAddPrice();
             Integer totalQuantity = reqOption.totalQuantity();
             Integer dailyLimit = reqOption.dailyLimit();
-            Integer currentDailyStock = reqOption.dailyLimit(); // 초기 생성 시에는 일일 한도와 같음
+            Integer currentDailyStock = Math.min(dailyLimit, totalQuantity);
 
             // DB 저장을 위한 Stock 객체 생성
             stocks.add(Stock.create(

--- a/src/main/java/com/michelet/inventory/domain/model/Stock.java
+++ b/src/main/java/com/michelet/inventory/domain/model/Stock.java
@@ -46,8 +46,8 @@ public class Stock extends BaseEntity implements Persistable<UUID> {
         this.optionId = optionId;
         this.totalQuantity = totalQuantity;
         this.dailyLimit = dailyLimit;
-        // 생성자 로직: 초기 재고는 일일 한도와 동일하게 설정
-        this.currentDailyStock = dailyLimit;
+        // 초기 재고 설정 시 일일 한도와 총 재고 중 작은 값으로 설정하여 논리적 모순 방지
+        this.currentDailyStock = Math.min(dailyLimit, totalQuantity);
         this.maxLimit = maxLimit != null ? maxLimit : 10;
     }
 

--- a/src/main/java/com/michelet/inventory/domain/model/Stock.java
+++ b/src/main/java/com/michelet/inventory/domain/model/Stock.java
@@ -110,14 +110,16 @@ public class Stock extends BaseEntity implements Persistable<UUID> {
         if (quantity <= 0) {
             throw new IllegalArgumentException("복구 수량은 0보다 커야 합니다.");
         }
-        // 1. 전체 재고 복구: Quantity 객체로 검증. 계산 후, 최종 숫자값만 필드에 대입
+        // 1. 전체 재고 복구
         this.totalQuantity = new Quantity(this.totalQuantity).plus(quantity).value();
 
-        // 2. 일일 재고 복구 (dailyLimit 이내로 제한)
+        // 2. 일일 재고 복구 (기존 값 + 복구량)
         int expectedDailyStock = this.currentDailyStock + quantity;
-        int restoredDailyStock = Math.min(expectedDailyStock, this.dailyLimit);
 
-        // 3. 필드 업데이트 (Quantity를 거쳐서 음수 여부 등 최종 검증)
+        // (계산된 일일 재고, 일일 한도, 방금 복구된 총 재고) 중 가장 작은 값을 선택
+        int restoredDailyStock = Math.min(expectedDailyStock, Math.min(this.dailyLimit, this.totalQuantity));
+
+        // 3. 필드 업데이트
         this.currentDailyStock = new Quantity(restoredDailyStock).value();
     }
 }

--- a/src/main/java/com/michelet/inventory/infrastructure/repository/JpaStockRepository.java
+++ b/src/main/java/com/michelet/inventory/infrastructure/repository/JpaStockRepository.java
@@ -9,7 +9,11 @@ import org.springframework.data.jpa.repository.Query;
 public interface JpaStockRepository extends JpaRepository<Stock, UUID> {
 
     // 일일재고복구 - 벌크 업데이트 쿼리
+    // dailyLimit, totalQuantity 중 작은 값으로 리셋함
     @Modifying(clearAutomatically = true)
-    @Query("UPDATE p_stocks s SET s.currentDailyStock = s.dailyLimit, s.version = s.version + 1 WHERE s.currentDailyStock <> s.dailyLimit")
+    @Query("UPDATE p_stocks s " +
+        "SET s.currentDailyStock = LEAST(s.dailyLimit, s.totalQuantity), " +
+        "    s.version = s.version + 1 " +
+        "WHERE s.currentDailyStock <> LEAST(s.dailyLimit, s.totalQuantity)")
     int resetDailyStock();
 }


### PR DESCRIPTION
## 📝 작업 내용
> 이번 PR에서 작업한 내용을 설명해주세요.

기존 로직 : 일일재고 수량을 무조건 일일구매제한값으로 세팅
이 경우 총 재고가 5개밖에 남지 않았는데 일일 재고 초기화 시 일일구매제한값 20으로 세팅되는 문제가 있었음

## 🚀 주요 변경 사항
> 완료한 이슈 번호 \
> Close #15   \
> 관련된 이슈 번호 (닫고 싶지 않은 경우) \
> Related to # 

## ✅ 자체 체크리스트 (필수)
- [x] `./gradlew build` 실행 결과 정상 (인증샷 첨부)
- [x] IntelliJ HTTP Client 테스트 완료 (인증샷 첨부)
- [x] 팀 내 컨벤션 준수 및 불필요한 로그, import 제거
- [x] 중요한 변경 사항이 팀에 공유되었는지

## 📸 테스트 인증샷
> 빌드 결과 및 IntelliJ HTTP Client 실행 화면을 여기에 첨부해 주세요.
<img width="489" height="55" alt="스크린샷 2026-05-04 오후 9 46 43" src="https://github.com/user-attachments/assets/174dfd49-98ba-44d3-ba68-4a39923086ea" />
<img width="999" height="370" alt="스크린샷 2026-05-04 오후 10 03 41" src="https://github.com/user-attachments/assets/48b50e3f-d110-40f6-b908-d4c150e7e2f4" />



## 💬 리뷰어 전달사항 (선택)
> 특별히 봐주었으면 하는 부분이나 논의가 필요한 점을 적어주세요.

테스트 시 inventory 쪽에서 로그인 후 하단 테스트 쪽으로 내려오셔서 그대로 실행하시면 됩니다

<br>

---
## 📎 참고 자료

> 관련 문서, 레퍼런스 링크 등이 있다면 여기에 첨부해주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Bug Fixes**
  * 일일 재고 한도가 총 수량을 초과하지 않도록 수정하였습니다.
  * 재고 복원 시 일일 재고 계산 로직을 개선하여 일관성을 강화했습니다.

* **Tests**
  * 재고 소진 및 자정 리셋 시나리오에 대한 검증 테스트를 추가하여 일일 한도 동기화를 확인합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->