### PR TITLE
Chore/29 - 부하테스트용 카탈로그 PerfDataInitializer 추가, application-perf.yml 추가

### DIFF
--- a/src/main/java/com/michelet/inventory/domain/model/Product.java
+++ b/src/main/java/com/michelet/inventory/domain/model/Product.java
@@ -78,7 +78,13 @@ public class Product extends BaseEntity {
 
     public static Product create(UUID restaurantId, String name, ProductCategory category, BigDecimal basePrice,
                                  Map<String, Object> attributes) {
-        return new Product(restaurantId, name, category, basePrice, attributes);
+        return Product.builder()
+            .restaurantId(restaurantId)
+            .name(name)
+            .category(category)
+            .basePrice(basePrice)
+            .attributes(attributes)
+            .build();
     }
 
     public Map<String, Object> getAttributes() {

--- a/src/main/java/com/michelet/inventory/infrastructure/config/PerfDataInitializer.java
+++ b/src/main/java/com/michelet/inventory/infrastructure/config/PerfDataInitializer.java
@@ -25,16 +25,20 @@ public class PerfDataInitializer implements ApplicationRunner {
     @Override
     @Transactional
     public void run(ApplicationArguments args) {
-        if (stockRepository.findById(TEST_OPTION_ID).isEmpty()) {
-            log.info("[PerfDataInitializer]-inventory : 1차 부하테스트용 무한 재고(100만)를 세팅함");
-            Stock stock = Stock.create(
-                TEST_OPTION_ID,
-                1000000, // totalQuantity
-                1000000, // dailyLimit
-                100      // maxLimit
-            );
-            stockRepository.save(stock);
-            log.info("[PerfDataInitializer] 재고 세팅 완료. OptionId: {}", TEST_OPTION_ID);
+        try {
+            if (stockRepository.findById(TEST_OPTION_ID).isEmpty()) {
+                log.info("[PerfDataInitializer]-inventory : 1차 부하테스트용 무한 재고(100만)를 세팅함");
+                Stock stock = Stock.create(
+                    TEST_OPTION_ID,
+                    1000000, // totalQuantity
+                    1000000, // dailyLimit
+                    100      // maxLimit
+                );
+                stockRepository.save(stock);
+                log.info("[PerfDataInitializer] 재고 세팅 완료. OptionId: {}", TEST_OPTION_ID);
+            }
+        } catch (Exception ex) {
+            log.error("[PerfDataInitializer] 특정 옵션 재고 초기화 실패. 대상 옵션아이디 : {}.", TEST_OPTION_ID, ex);
         }
     }
 }

--- a/src/main/java/com/michelet/inventory/infrastructure/config/PerfDataInitializer.java
+++ b/src/main/java/com/michelet/inventory/infrastructure/config/PerfDataInitializer.java
@@ -1,0 +1,40 @@
+package com.michelet.inventory.infrastructure.config;
+
+import com.michelet.inventory.domain.model.Stock;
+import com.michelet.inventory.domain.repository.StockRepository;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Component
+@Profile("perf")
+@RequiredArgsConstructor
+public class PerfDataInitializer implements ApplicationRunner {
+
+    private final StockRepository stockRepository;
+
+    // 타격 타겟 고정 Option ID
+    public static final UUID TEST_OPTION_ID = UUID.fromString("44444444-4444-4444-4444-444444444444");
+
+    @Override
+    @Transactional
+    public void run(ApplicationArguments args) {
+        if (stockRepository.findById(TEST_OPTION_ID).isEmpty()) {
+            log.info("[PerfDataInitializer]-inventory : 1차 부하테스트용 무한 재고(100만)를 세팅함");
+            Stock stock = Stock.create(
+                TEST_OPTION_ID,
+                1000000, // totalQuantity
+                1000000, // dailyLimit
+                100      // maxLimit
+            );
+            stockRepository.save(stock);
+            log.info("[PerfDataInitializer] 재고 세팅 완료. OptionId: {}", TEST_OPTION_ID);
+        }
+    }
+}

--- a/src/main/resources/application-perf.yml
+++ b/src/main/resources/application-perf.yml
@@ -6,8 +6,8 @@ spring:
     datasource:
         hikari:
             maximum-pool-size: 10      # DB 커넥션 풀을 10개로 제한하여 병목 유발
-            minimum-idle: 10
-            connection-timeout: 30000  # 30초 대기 후 ConnectionTimeout(500 에러) 발생
+            minimum-idle: 2           # 풀 탄력성을 위해 최소 유휴 커넥션을 2로 낮춤
+            connection-timeout: 5000  # 빠른 병목 관찰을 위해 30초 -> 5초로 단축. 대기 후 ConnectionTimeout(500 에러) 발생
 
     jpa:
         show-sql: false # 수만 건의 쿼리가 콘솔에 찍히면 I/O 병목이 생기므로 반드시 꺼야 함

--- a/src/main/resources/application-perf.yml
+++ b/src/main/resources/application-perf.yml
@@ -1,0 +1,21 @@
+spring:
+    config:
+        activate:
+            on-profile: perf
+
+    datasource:
+        hikari:
+            maximum-pool-size: 10      # DB 커넥션 풀을 10개로 제한하여 병목 유발
+            minimum-idle: 10
+            connection-timeout: 30000  # 30초 대기 후 ConnectionTimeout(500 에러) 발생
+
+    jpa:
+        show-sql: false # 수만 건의 쿼리가 콘솔에 찍히면 I/O 병목이 생기므로 반드시 꺼야 함
+        properties:
+            hibernate:
+                format_sql: false
+
+logging:
+    level:
+        root: INFO
+        com.michelet: INFO


### PR DESCRIPTION
## 📝 작업 내용
> 이번 PR에서 작업한 내용을 설명해주세요.
- 주문 생성 1차 부하테스트를 위한 재고 더미데이터 생성

## 🚀 주요 변경 사항
> 완료한 이슈 번호 \
> Close #29  \
> 관련된 이슈 번호 (닫고 싶지 않은 경우) \
> Related to # 

## ✅ 자체 체크리스트 (필수)
- [x] `./gradlew build` 실행 결과 정상 (인증샷 첨부)
- [x] IntelliJ HTTP Client 테스트 완료 (인증샷 첨부)
- [x] 팀 내 컨벤션 준수 및 불필요한 로그, import 제거
- [x] 중요한 변경 사항이 팀에 공유되었는지

## 📸 테스트 인증샷
> 빌드 결과 및 IntelliJ HTTP Client 실행 화면을 여기에 첨부해 주세요.

## 💬 리뷰어 전달사항 (선택)
> 특별히 봐주었으면 하는 부분이나 논의가 필요한 점을 적어주세요.

<br>

---
## 📎 참고 자료

> 관련 문서, 레퍼런스 링크 등이 있다면 여기에 첨부해주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **신규 기능**
  * 성능 테스트 프로필(`perf`) 추가 - 데이터베이스 연결 풀 설정(최대 10개, 최소 유휴 10개) 및 30초 연결 타임아웃 지원
  * 성능 테스트용 초기 테스트 데이터 자동 생성 기능 추가

* **정리**
  * 내부 객체 생성 방식 최적화

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Miche-Let/inventory-service/pull/30)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->