### PR TITLE
feat/33 - DLT 컨슈머

### DIFF
--- a/src/main/java/com/michelet/inventory/infrastructure/config/JpaConfig.java
+++ b/src/main/java/com/michelet/inventory/infrastructure/config/JpaConfig.java
@@ -1,0 +1,10 @@
+package com.michelet.inventory.infrastructure.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+
+@Configuration
+// Redis와 스캔 충돌을 막기 위해 패키지 명시
+@EnableJpaRepositories(basePackages = "com.michelet.inventory.infrastructure.repository")
+public class JpaConfig {
+}

--- a/src/main/java/com/michelet/inventory/infrastructure/messaging/DeadLetterConsumer.java
+++ b/src/main/java/com/michelet/inventory/infrastructure/messaging/DeadLetterConsumer.java
@@ -20,8 +20,8 @@ public class DeadLetterConsumer {
     @KafkaListener(
         topics = {
             "${inventory.kafka.topic.restore-request:order.stock-restore.requested}.DLT",
-            "${inventory.kafka.topic.stock-restored:stock.restored}.DLT",
-            "${inventory.kafka.topic.stock-reserved:stock.reserved}.DLT"
+            "${inventory.kafka.topic.restored:stock.restored}.DLT",
+            "${inventory.kafka.topic.reserved:stock.reserved}.DLT"
         },
         groupId = "${spring.kafka.consumer.group-id:inventory-service-consumer}-dlt",
         containerFactory = "dltListenerContainerFactory" // String 전용 팩토리 사용

--- a/src/main/java/com/michelet/inventory/infrastructure/messaging/DeadLetterConsumer.java
+++ b/src/main/java/com/michelet/inventory/infrastructure/messaging/DeadLetterConsumer.java
@@ -1,0 +1,57 @@
+package com.michelet.inventory.infrastructure.messaging;
+
+import java.nio.charset.StandardCharsets;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.common.header.Header;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.kafka.support.KafkaHeaders;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class DeadLetterConsumer {
+
+    /**
+     * Inventory 서비스의 주요 도메인 로직(재고 복구 등) 실패 시 격리된 메시지를 수신 - 3회 재시도 후에도 실패한 '독성 메시지'를 분석하기 위한 전용 컨슈머
+     */
+    @KafkaListener(
+        topics = {
+            "${inventory.kafka.topic.restore-request:order.stock-restore.requested}.DLT",
+            "${inventory.kafka.topic.stock-restored:stock.restored}.DLT",
+            "${inventory.kafka.topic.stock-reserved:stock.reserved}.DLT"
+        },
+        groupId = "${spring.kafka.consumer.group-id:inventory-service-consumer}-dlt",
+        containerFactory = "dltListenerContainerFactory" // String 전용 팩토리 사용
+    )
+    public void consumeInventoryDLT(ConsumerRecord<String, String> record) {
+        String originalTopic = extractHeaderAsString(record, KafkaHeaders.DLT_ORIGINAL_TOPIC);
+        String exceptionMessage = extractHeaderAsString(record, KafkaHeaders.DLT_EXCEPTION_MESSAGE);
+        String stackTrace = extractHeaderAsString(record, KafkaHeaders.DLT_EXCEPTION_STACKTRACE);
+
+        log.error("""
+                ================================================================================
+                [CRITICAL ALERT] 인벤토리 DLT 에러 메시지 격리 수신 (최종 실패)
+                원본 토픽 : {}
+                에러 원인 : {}
+                원본 데이터 : {}
+                상세 트레이스 : 
+                {}
+                ================================================================================""",
+            originalTopic,
+            exceptionMessage,
+            record.value() != null ? record.value() : "데이터 없음",
+            stackTrace
+        );
+    }
+
+    private String extractHeaderAsString(ConsumerRecord<String, String> record, String headerKey) {
+        Header header = record.headers().lastHeader(headerKey);
+        if (header != null && header.value() != null) {
+            return new String(header.value(), StandardCharsets.UTF_8);
+        }
+        return "알 수 없음";
+    }
+}

--- a/src/main/java/com/michelet/inventory/infrastructure/messaging/OrderEventConsumer.java
+++ b/src/main/java/com/michelet/inventory/infrastructure/messaging/OrderEventConsumer.java
@@ -19,7 +19,7 @@ public class OrderEventConsumer {
         topics = "${inventory.kafka.topic.restore-request:order.stock-restore.requested}",
         groupId = "${spring.kafka.consumer.group-id:inventory-service-consumer}"
     )
-    public void consumeStockRestoredEvent(StockRestoreMessage payload) {
+    public void consumeStockRestoreRequest(StockRestoreMessage payload) {
         if (payload == null) {
             log.error("[Kafka Consumer] 잘못된 복구 이벤트 수신: payload가 null입니다 (Tombstone 메시지일 가능성).");
             // IllegalArgumentException을 던지면 아래 catch 블록에서 잡지 않고 밖으로 던져져서 DLT로 직행함

--- a/src/main/java/com/michelet/inventory/infrastructure/messaging/OrderEventConsumer.java
+++ b/src/main/java/com/michelet/inventory/infrastructure/messaging/OrderEventConsumer.java
@@ -16,7 +16,7 @@ public class OrderEventConsumer {
     private final StockLockFacade stockLockFacade;
 
     @KafkaListener(
-        topics = "${inventory.kafka.topic.restored:stock.restored}",
+        topics = "${inventory.kafka.topic.restore-request:order.stock-restore.requested}",
         groupId = "${spring.kafka.consumer.group-id:inventory-service-consumer}"
     )
     public void consumeStockRestoredEvent(StockRestoreMessage payload) {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -4,6 +4,7 @@ spring:
     profiles:
         active: local
     jpa:
+        open-in-view: false
         show-sql: false
         properties:
             hibernate:
@@ -31,7 +32,7 @@ spring:
             properties:
                 # 실제 역직렬화를 수행할 델리게이트 클래스 지정
                 spring.deserializer.value.delegate.class: org.springframework.kafka.support.serializer.JsonDeserializer
-                spring.json.trusted.packages: "com.michelet.inventory.infrastructure.messaging.dto"
+                spring.json.trusted.packages: "com.michelet.*"
                 spring.json.use.type.headers: true
                 # 서로 다른 패키지의 이벤트를 1:1로 매핑
                 spring.json.type.mapping: "com.michelet.order.application.dto.StockRestoreEventPayload:com.michelet.inventory.infrastructure.messaging.dto.StockRestoreMessage"
@@ -47,7 +48,8 @@ inventory:
         topic:
             product-created: "product.created"
             reserved: "stock.reserved"
-            restored: "stock.restored"
+            restore-request: "order.stock-restore.requested" # 오더의 '명령'을 수신할 토픽
+            restored: "stock.restored" # 카탈로그로 '결과'를 발송할 토픽
             status-changed: "product.status-changed"
             daily-reset: "stock.daily-reset"
             product-updated: "product.updated"

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -32,7 +32,7 @@ spring:
             properties:
                 # 실제 역직렬화를 수행할 델리게이트 클래스 지정
                 spring.deserializer.value.delegate.class: org.springframework.kafka.support.serializer.JsonDeserializer
-                spring.json.trusted.packages: "com.michelet.*"
+                spring.json.trusted.packages: "com.michelet.inventory.infrastructure.messaging.dto,com.michelet.order.application.dto"
                 spring.json.use.type.headers: true
                 # 서로 다른 패키지의 이벤트를 1:1로 매핑
                 spring.json.type.mapping: "com.michelet.order.application.dto.StockRestoreEventPayload:com.michelet.inventory.infrastructure.messaging.dto.StockRestoreMessage"


### PR DESCRIPTION
## 📝 작업 내용
> 이번 PR에서 작업한 내용을 설명해주세요.
- DLT 컨슈머 구축
- 토픽 이름 충돌 결함 수정
- Kafka 역직렬화 신뢰 정책 완화, 
- OSIV 비활성화 및 JpaConfig 분리

## 🚀 주요 변경 사항
> 완료한 이슈 번호 \
> Close #33   \
> 관련된 이슈 번호 (닫고 싶지 않은 경우) \
> Related to # 

## ✅ 자체 체크리스트 (필수)
- [x] `./gradlew build` 실행 결과 정상 (인증샷 첨부)
- [x] IntelliJ HTTP Client 테스트 완료 (인증샷 첨부)
- [x] 팀 내 컨벤션 준수 및 불필요한 로그, import 제거
- [x] 중요한 변경 사항이 팀에 공유되었는지

## 📸 테스트 인증샷
> 빌드 결과 및 IntelliJ HTTP Client 실행 화면을 여기에 첨부해 주세요.
<img width="1251" height="71" alt="스크린샷 2026-05-14 오후 2 59 30" src="https://github.com/user-attachments/assets/c3954934-d10d-4135-b890-fac76cc3d0cb" />
<img width="1262" height="73" alt="스크린샷 2026-05-14 오후 2 59 37" src="https://github.com/user-attachments/assets/b73d3add-ed95-4fe0-9a5b-fa392e49ce85" />
<img width="1253" height="71" alt="스크린샷 2026-05-14 오후 2 59 44" src="https://github.com/user-attachments/assets/1e9c420b-cde8-447d-af21-a4e3ad765464" />
<img width="1253" height="65" alt="스크린샷 2026-05-14 오후 2 59 51" src="https://github.com/user-attachments/assets/2f5f89ed-e283-413b-a3bc-9c8668bed12a" />
<img width="1258" height="350" alt="스크린샷 2026-05-14 오후 3 00 05" src="https://github.com/user-attachments/assets/72e481c2-ac20-4489-9e57-f3096112dc75" />
<img width="1250" height="617" alt="스크린샷 2026-05-14 오후 3 01 22" src="https://github.com/user-attachments/assets/781ada7a-ce5d-440a-8cb5-5ac77f285161" />


## 💬 리뷰어 전달사항 (선택)
> 특별히 봐주었으면 하는 부분이나 논의가 필요한 점을 적어주세요.

* 사진으로 첨부한 테스트는 OrderEventConsumer의 `consumeStockRestoredEvent` 에서 무조건 에러를 내도록 수정해 진행했던 테스트입니다. pr로 올린 코드에선 해당 에러 발생 부분을 삭제했습니다. (그냥 조용히 DLT로 갑니다)

<br>

---
## 📎 참고 자료

> 관련 문서, 레퍼런스 링크 등이 있다면 여기에 첨부해주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * JPA 관련 설정 추가로 데이터 접근 구성 개선
  * 데드레터(DLT) 메시지 수집기 추가로 메시징 오류 감지 강화

* **개선 사항**
  * 재고 복구 요청 토픽 구독으로 재고 요청 처리 흐름 업데이트
  * 애플리케이션 설정 최적화(세션 관리 비활성화 및 메시지 직렬화 신뢰 패키지 확장)

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Miche-Let/inventory-service/pull/34)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->